### PR TITLE
Fix footer collapse with page main content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Collapsing element in the store template container.
 
 ## [0.2.0] - 2018-6-5
 

--- a/react/StoreTemplate.js
+++ b/react/StoreTemplate.js
@@ -12,7 +12,7 @@ export default class StoreTemplate extends Component {
       <Fragment>
         <ExtensionPoint id="theme" />
         <ExtensionPoint id="header" />
-        <div className="vtex-store__template w-100 h-100">{this.props.children}</div>
+        <div className="vtex-store__template w-100">{this.props.children}</div>
         <ExtensionPoint id="footer" />
       </Fragment>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Removes the height-limiting class `h-100` of the content div in `StoreTemplate`. 

#### What problem is this solving?
The main content of the page had the `h-100` class, which limited the height of this container to the height of their parent (`div.render-provider`) and made the children overflow the `div`. 

In the case of `dreamstore-theme`, the carousel and shelf components were bigger than this container, and it made them overflow this div, making them collide with the footer component that is bellow the container.

#### How should this be manually tested?
[Access this workspace](https://lucas--storecomponents.myvtex.com/).

#### Screenshots or example usage
* Colliding components:
![image](https://user-images.githubusercontent.com/10223856/41103135-cafd2994-6a3e-11e8-8c3b-d63ec08dde83.png)

* Fixed:
![image](https://user-images.githubusercontent.com/10223856/41103223-f8dac894-6a3e-11e8-8cdf-40adca48cfc9.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
