### PR TITLE
Pass down product object on product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.2.1] - 2018-6-11
+## [0.2.2] - 2018-6-11
 
 ### Added
 - Add product prop in _ProductPage_ component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.1] - 2018-6-11
+
+### Added
+- Add product prop in _ProductPage_ component.
+- Add `linkText`, `brand`, `referenceId` in product query.
+
 ## [0.2.0] - 2018-6-5
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/react/ProductPage.js
+++ b/react/ProductPage.js
@@ -29,6 +29,7 @@ class ProductPage extends Component {
               id="container"
               slug={variables.slug}
               categories={product.categories}
+              product={product}
             />
           )}
         </div>

--- a/react/queries/productQuery.gql
+++ b/react/queries/productQuery.gql
@@ -3,12 +3,18 @@ query Product($slug: String) {
     productName
     productId
     description
+    linkText
+    brand
     items {
       itemId
       name
       nameComplete
       complementName
       ean
+      referenceId {
+        Key
+        Value
+      }
       measurementUnit
       unitMultiplier
       images {


### PR DESCRIPTION
#### What is the purpose of this pull request?
* Pass product object down to product page children.
* Add a few attributes to the product query.

#### What problem is this solving?
* The product page children did not know which product they were representing.
* The app store needed those attributes.

#### Types of changes
* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
