### PR TITLE
Fix SearchPage ExtensionPoint props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Pass props to the extensionPoint of `SearchPage`.
+- Modify `store/search` path from `/:term/` to `/:term/s`
 
 ## [0.2.3] - 2018-6-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
+### Changed
 - Pass props to the extensionPoint of `SearchPage`.
 
 ## [0.2.3] - 2018-6-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Pass props to the extensionPoint of `SearchPage`.
 
 ## [0.2.3] - 2018-6-11
 

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -28,7 +28,7 @@
       "path": "/:department/:category/:subcategory"
     },
     "store/search": {
-      "path": "/:term"
+      "path": "/:term/s"
     },
     "store/product": {
       "path": "/:slug/p"

--- a/react/SearchPage.js
+++ b/react/SearchPage.js
@@ -5,13 +5,27 @@ import { ExtensionPoint } from 'render'
 export default class SearchPage extends Component {
   static propTypes = {
     params: PropTypes.shape({
+      /** Search's term, e.g: eletronics. */
       term: PropTypes.string.isRequired,
     }),
+    query: PropTypes.shape({
+      /** 
+       * Rest of the search term, e.g: eletronics/smartphones/samsung implies that
+       * Q will be equal to "smartphones,samsung".
+       * */
+      Q: PropTypes.string,
+      /** Determines the types of the terms, e.g: "c,c,b" (category, category, brand). */
+      map: PropTypes.string,
+      /** Search's pagination.  */
+      page: PropTypes.string,
+      /** Search's ordenation. */
+      O: PropTypes.string,
+    })
   }
 
   render() {
     return (
-      <ExtensionPoint id="container" />
+      <ExtensionPoint id="container" {...this.props} />
     )
   }
 }

--- a/react/SearchPage.js
+++ b/react/SearchPage.js
@@ -9,18 +9,18 @@ export default class SearchPage extends Component {
       term: PropTypes.string.isRequired,
     }),
     query: PropTypes.shape({
-      /** 
+      /**
        * Rest of the search term, e.g: eletronics/smartphones/samsung implies that
        * Q will be equal to "smartphones,samsung".
        * */
-      Q: PropTypes.string,
+      rest: PropTypes.string,
       /** Determines the types of the terms, e.g: "c,c,b" (category, category, brand). */
       map: PropTypes.string,
       /** Search's pagination.  */
       page: PropTypes.string,
       /** Search's ordenation. */
-      O: PropTypes.string,
-    })
+      order: PropTypes.string,
+    }),
   }
 
   render() {

--- a/react/SearchPage.js
+++ b/react/SearchPage.js
@@ -11,7 +11,7 @@ export default class SearchPage extends Component {
     query: PropTypes.shape({
       /**
        * Rest of the search term, e.g: eletronics/smartphones/samsung implies that
-       * Q will be equal to "smartphones,samsung".
+       * rest will be equal to "smartphones,samsung".
        * */
       rest: PropTypes.string,
       /** Determines the types of the terms, e.g: "c,c,b" (category, category, brand). */


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Pass some props that are missing in the ExtensionPoint inside SearchPage

#### What problem is this solving?
- Fix the problem in the SSR of search-result app

#### How should this be manually tested?
[workspace link](https://claudivan--storecomponents.myvtex.com/Eletronics?O=OrderByBestDiscountDESC&Q=Smartphones&map=c%2Cc&page=1)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
