### PR TITLE
Add more data on productQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed 
+- Add more data on productQuery
 
 ## [0.2.6] - 2018-6-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed 
-- Add more data on productQuery
+- Add `variations` and `properties` on productQuery.
 
 ## [0.2.6] - 2018-6-18
 ### Changed

--- a/react/CategoryPage.js
+++ b/react/CategoryPage.js
@@ -21,7 +21,7 @@ export default class CategoryPage extends Component {
 
   render() {
     return (
-      <ExtensionPoint id="container" />
+      <ExtensionPoint id="container" {...this.props} />
     )
   }
 }

--- a/react/queries/productQuery.gql
+++ b/react/queries/productQuery.gql
@@ -7,6 +7,10 @@ query Product($slug: String) {
     categories
     categoryId
     brand
+    properties {
+      name,
+      values
+    },
     items {
       itemId
       name
@@ -41,6 +45,9 @@ query Product($slug: String) {
           Tax
           CacheVersionUsedToCallCheckout
         }
+      }
+      variations {
+        name
       }
     }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add more data on `productQuery.gql`

**Secondary** Passing props for `ExtensionPoint` at CategoryPage

#### Screenshots or example usage
https://store--storecomponents.myvtex.com/ninja-300/p

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
