### PR TITLE
Add categoriesIds field on productQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed 
+- Add `categoriesIds` on productQuery.
+
 ## [0.2.7] - 2018-6-20
 ### Changed 
 - Add `variations` and `properties` on productQuery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.8] - 2018-6-20
+
 ### Changed 
 - Add `categoriesIds` on productQuery.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/react/queries/productQuery.gql
+++ b/react/queries/productQuery.gql
@@ -6,6 +6,7 @@ query Product($slug: String) {
     linkText
     categories
     categoryId
+    categoriesIds
     brand
     properties {
       name,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `categoriesIds` field on productQuery

#### Types of changes
* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
