### PR TITLE
Add data layer to product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add the `SearchPage` GraphQL queries.
+- Data layer intergration in the `ProductPage`.
 
 ## [0.3.0] - 2018-6-25
 ### Added

--- a/react/ProductPage.js
+++ b/react/ProductPage.js
@@ -1,20 +1,47 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { graphql } from 'react-apollo'
+import { graphql, compose } from 'react-apollo'
 import { ExtensionPoint } from 'render'
+
+import withDataLayer, { dataLayerProps } from './components/withDataLayer'
 import productQuery from './queries/productQuery.gql'
 
 class ProductPage extends Component {
   static contextTypes = {
     prefetchPage: PropTypes.func,
   }
+
   static propTypes = {
     params: PropTypes.object,
     data: PropTypes.object,
+    ...dataLayerProps,
+  }
+
+  pushToDataLayer = product => {
+    this.props.pushToDataLayer({
+      ecommerce: {
+        detail: {
+          products: [{
+            name: product.productName,
+            brand: product.brand,
+          }],
+        },
+      },
+    })
   }
 
   componentDidMount() {
     this.context.prefetchPage('store/home')
+
+    if (!this.props.data.loading) {
+      this.pushToDataLayer(this.props.data.product)
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.data.loading && !this.props.data.loading) {
+      this.pushToDataLayer(this.props.data.product)
+    }
   }
 
   render() {
@@ -22,17 +49,15 @@ class ProductPage extends Component {
     const { loading, variables, product } = data
 
     return (
-      <div>
-        <div className="vtex-product-details-container">
-          {!loading && (
-            <ExtensionPoint
-              id="container"
-              slug={variables.slug}
-              categories={product.categories}
-              product={product}
-            />
-          )}
-        </div>
+      <div className="vtex-product-details-container">
+        {!loading && (
+          <ExtensionPoint
+            id="container"
+            slug={variables.slug}
+            categories={product.categories}
+            product={product}
+          />
+        )}
       </div>
     )
   }
@@ -46,6 +71,7 @@ const options = {
   }),
 }
 
-export default graphql(productQuery, options)(
-  ProductPage
-)
+export default compose(
+  graphql(productQuery, options),
+  withDataLayer
+)(ProductPage)

--- a/react/ProductPage.js
+++ b/react/ProductPage.js
@@ -25,6 +25,8 @@ class ProductPage extends Component {
           products: [{
             name: product.productName,
             brand: product.brand,
+            category: product.categories.length > 0 ? product.categories[0] : undefined,
+            id: product.productId,
           }],
         },
       },

--- a/react/ProductPage.js
+++ b/react/ProductPage.js
@@ -19,6 +19,7 @@ class ProductPage extends Component {
 
   pushToDataLayer = product => {
     this.props.pushToDataLayer({
+      event: 'productDetail',
       ecommerce: {
         detail: {
           products: [{

--- a/react/StoreTemplate.js
+++ b/react/StoreTemplate.js
@@ -1,20 +1,33 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { ExtensionPoint } from 'render'
+
+import { DataLayerProvider } from './components/withDataLayer'
 
 export default class StoreTemplate extends Component {
   static propTypes = {
     children: PropTypes.element,
   }
 
+  pushToDataLayer = obj => {
+    window.dataLayer.push(obj)
+  }
+
   render() {
+    window.dataLayer = window.dataLayer || []
+
     return (
-      <Fragment>
+      <DataLayerProvider
+        value={{
+          dataLayer: window.dataLayer,
+          pushToDataLayer: this.pushToDataLayer,
+        }}
+      >
         <ExtensionPoint id="theme" />
         <ExtensionPoint id="header" />
         <div className="vtex-store__template">{this.props.children}</div>
         <ExtensionPoint id="footer" />
-      </Fragment>
+      </DataLayerProvider>
     )
   }
 }

--- a/react/components/withDataLayer.js
+++ b/react/components/withDataLayer.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+const { Consumer, Provider } = React.createContext({
+  dataLayer: [],
+  pushToDataLayer: () => {},
+})
+
+export { Provider as DataLayerProvider }
+
+export default function withDataLayer(WrappedComponent) {
+  return class DataLayer extends Component {
+    static displayName =
+      `DataLayer(${WrappedComponent.displayName || WrappedComponent.name})`
+
+    render() {
+      return (
+        <Consumer>
+          {context => (
+            <WrappedComponent {...this.props} {...context} />
+          )}
+        </Consumer>
+      )
+    }
+  }
+}
+
+export const dataLayerProps = {
+  dataLayer: PropTypes.array.isRequired,
+  pushToDataLayer: PropTypes.func.isRequired,
+}
+


### PR DESCRIPTION
#### What is the purpose of this pull request?
On the product page, add the product details data to the data layer array.

#### How should this be manually tested?
[Access this workspace](https://datalayer--storecomponents.myvtex.com/ninja-300/p) and see the `dataLayer` array on the console.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
