### PR TITLE
Add the SearchResult's GraphQL queries to the SearchPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the `SearchPage` GraphQL queries.
 
 ## [0.3.0] - 2018-6-25
 ### Added

--- a/react/SearchPage.js
+++ b/react/SearchPage.js
@@ -1,12 +1,26 @@
-import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { compose, graphql } from 'react-apollo'
 import { ExtensionPoint } from 'render'
 
-export default class SearchPage extends Component {
+import { facetsQueryShape, searchQueryShape } from './constants/propTypes'
+import { createMap, joinPathWithRest, reversePagesPath } from './helpers/searchHelpers'
+import facetsQuery from './queries/facetsQuery.gql'
+import searchQuery from './queries/searchQuery.gql'
+
+const DEFAULT_PAGE = 1
+
+class SearchPage extends Component {
   static propTypes = {
     params: PropTypes.shape({
       /** Search's term, e.g: eletronics. */
       term: PropTypes.string.isRequired,
+      /** Department param. */
+      department: PropTypes.string,
+      /** Category param. */
+      category: PropTypes.string,
+      /** Subcategory param. */
+      subcategory: PropTypes.string,
     }),
     query: PropTypes.shape({
       /**
@@ -21,11 +35,68 @@ export default class SearchPage extends Component {
       /** Search's ordenation. */
       order: PropTypes.string,
     }),
+    /** Internal route path. e.g: 'store/search' */
+    treePath: PropTypes.string,
+    /** Facets graphql query. */
+    facetsQuery: facetsQueryShape,
+    /** Search graphql query. */
+    searchQuery: searchQueryShape,
   }
 
   render() {
-    return (
-      <ExtensionPoint id="container" {...this.props} pagesPath={this.props.treePath}/>
-    )
+    const {
+      treePath,
+      query: { order: orderBy, page: pageProps, map: mapProps, rest },
+    } = this.props
+    const pathName = reversePagesPath(treePath, this.props.params)
+    const map = mapProps || createMap(pathName, rest)
+    const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE
+    const containerProps = {
+      ...this.props,
+      path: pathName,
+      map,
+      rest,
+      page,
+      orderBy,
+      pagesPath: treePath,
+    }
+    return <ExtensionPoint id="container" {...containerProps} />
   }
 }
+
+export default compose(
+  graphql(facetsQuery, {
+    name: 'facetsQuery',
+    options: props => {
+      const { treePath, params, rest, map: mapProps } = props
+      const path = reversePagesPath(treePath, params)
+      const query = joinPathWithRest(path, rest)
+      const facets = `${query}?map=${mapProps || createMap(path, rest)}`
+      return {
+        variables: { facets },
+      }
+    },
+  }),
+  graphql(searchQuery, {
+    name: 'searchQuery',
+    options: props => {
+      const {
+        treePath,
+        rest,
+        map,
+        params,
+        orderBy,
+        page,
+        maxItemsPerPage,
+      } = props
+      const path = reversePagesPath(treePath, params)
+      const query = joinPathWithRest(path, rest)
+      const from = (page - 1) * maxItemsPerPage
+      const to = from + maxItemsPerPage - 1
+      return {
+        variables: { query, map, orderBy, from, to },
+        notifyOnNetworkStatusChange: true,
+      }
+    },
+  })
+)(SearchPage)

--- a/react/SearchPage.js
+++ b/react/SearchPage.js
@@ -64,7 +64,7 @@ class SearchPage extends Component {
   }
 }
 
-export default compose(
+compose(
   graphql(facetsQuery, {
     name: 'facetsQuery',
     options: props => {

--- a/react/SearchPage.js
+++ b/react/SearchPage.js
@@ -13,6 +13,12 @@ const DEFAULT_PAGE = 1
 const DEFAULT_MAX_ITEMS_PER_PAGE = 1
 
 export default class SearchPage extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = { maxItemsPerPage: DEFAULT_MAX_ITEMS_PER_PAGE }
+  }
+
   static propTypes = {
     params: PropTypes.shape({
       /** Search's term, e.g: eletronics. */
@@ -37,12 +43,6 @@ export default class SearchPage extends Component {
     facetsQuery: facetsQueryShape,
     /** Search graphql query. */
     searchQuery: searchQueryShape,
-  }
-
-  constructor(props) {
-    super(props)
-
-    this.state = { maxItemsPerPage: DEFAULT_MAX_ITEMS_PER_PAGE }
   }
 
   render() {

--- a/react/SearchPage.js
+++ b/react/SearchPage.js
@@ -88,7 +88,7 @@ export default class SearchPage extends Component {
                 {...containerProps}
                 searchQuery={{ ...searchQueryProps, ...searchQueryProps.data }}
                 facetsQuery={{ ...facetsQueryProps, ...facetsQueryProps.data }}
-                setVariables={variables => this.setState(variables)}
+                setContextVariables={variables => this.setState(variables)}
               />
             )}
           </Query>

--- a/react/SearchPage.js
+++ b/react/SearchPage.js
@@ -10,7 +10,7 @@ import facetsQuery from './queries/facetsQuery.gql'
 import searchQuery from './queries/searchQuery.gql'
 
 const DEFAULT_PAGE = 1
-const DEFAULT_MAX_ITEMS = 1
+const DEFAULT_MAX_ITEMS_PER_PAGE = 1
 
 class SearchPage extends Component {
   static propTypes = {
@@ -45,32 +45,6 @@ class SearchPage extends Component {
     searchQuery: searchQueryShape,
   }
 
-  prefetch = ({
-    searchQuery: {
-      variables: { maxItemsPerPage, ...restOfVariables },
-      onUpdateQuery,
-    } = {},
-  }) => {
-    const {
-      query: { page: pageProps },
-    } = this.props
-    const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE
-    const from = (page - 1) * maxItemsPerPage
-    const to = from + maxItemsPerPage - 1
-
-    this.props.searchQuery.fetchMore({
-      variables: {
-        from,
-        to,
-        ...restOfVariables,
-      },
-      updateQuery: (_, { fetchMoreResult }) => {
-        onUpdateQuery(fetchMoreResult)
-        return fetchMoreResult
-      },
-    })
-  }
-
   render() {
     const {
       treePath,
@@ -82,19 +56,20 @@ class SearchPage extends Component {
         rest = '',
       },
     } = this.props
-    const pathName = reversePagesPath(treePath, params)
-    const map = mapProps || createMap(pathName, rest)
+
+    const path = reversePagesPath(treePath, params)
+    const map = mapProps || createMap(path, rest)
     const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE
     const containerProps = {
       ...this.props,
-      path: pathName,
+      path,
       map,
       rest,
       page,
       orderBy,
       pagesPath: treePath,
-      prefetch: this.prefetch,
     }
+
     return <ExtensionPoint id="container" {...containerProps} />
   }
 }
@@ -127,7 +102,7 @@ export default compose(
           map = createMap(path, rest),
           rest,
         },
-        maxItemsPerPage = DEFAULT_MAX_ITEMS,
+        maxItemsPerPage = DEFAULT_MAX_ITEMS_PER_PAGE,
       } = props
       const query = joinPathWithRest(path, rest)
       const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -34,6 +34,8 @@ export const productShape = PropTypes.shape({
       /** SKU's referenceId. */
       referenceId: PropTypes.arrayOf(
         PropTypes.shape({
+          /** ReferenceId's key. */
+          Key: PropTypes.string.isRequired,
           /** ReferenceId's value. */
           Value: PropTypes.string.isRequired,
         })

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -1,0 +1,123 @@
+import PropTypes from 'prop-types'
+
+export const facetOptionShape = PropTypes.shape({
+  /** Quantity of products matched with the facet option. */
+  Quantity: PropTypes.number.isRequired,
+  /** Link of the facets option. */
+  Link: PropTypes.string.isRequired,
+  /** Name of the facet option. */
+  Name: PropTypes.string.isRequired,
+})
+
+export const productShape = PropTypes.shape({
+  /** Product's id. */
+  productId: PropTypes.string.isRequired,
+  /** Product's name. */
+  productName: PropTypes.string.isRequired,
+  /** Product's description. */
+  description: PropTypes.string.isRequired,
+  /** Product's categories. */
+  categories: PropTypes.array,
+  /** Product's link. */
+  link: PropTypes.string,
+  /** Product's link text. */
+  linkText: PropTypes.string.isRequired,
+  /** Product's brand. */
+  brand: PropTypes.string,
+  /** Product's SKU items. */
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** SKU's id. */
+      itemId: PropTypes.string.isRequired,
+      /** SKU's name. */
+      name: PropTypes.string.isRequired,
+      /** SKU's referenceId. */
+      referenceId: PropTypes.arrayOf(
+        PropTypes.shape({
+          /** ReferenceId's value. */
+          Value: PropTypes.string.isRequired,
+        })
+      ),
+      /** SKU's images. */
+      images: PropTypes.arrayOf(
+        PropTypes.shape({
+          /** Images's imageUrl. */
+          imageUrl: PropTypes.string.isRequired,
+          /** Images's imageTag. */
+          imageTag: PropTypes.string.isRequired,
+        })
+      ).isRequired,
+      /** SKU's sellers. */
+      sellers: PropTypes.arrayOf(
+        PropTypes.shape({
+          /** Sellers's commertialOffer. */
+          commertialOffer: PropTypes.shape({
+            /** CommertialOffer's price. */
+            Price: PropTypes.number.isRequired,
+            /** CommertialOffer's list price. */
+            ListPrice: PropTypes.number.isRequired,
+          }).isRequired,
+        })
+      ).isRequired,
+    })
+  ).isRequired,
+})
+
+export const facetsQueryShape = PropTypes.shape({
+  /** Departments matched with the facets. */
+  Departments: PropTypes.arrayOf(facetOptionShape),
+  /** Brands matched with the facets. */
+  Brands: PropTypes.arrayOf(facetOptionShape),
+  /** SpecificationFilters matched with the facets. */
+  SpecificationFilters: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** SpecificationFilter's name. */
+      name: PropTypes.string.isRequired,
+      /** SpecificationFilter's facets. */
+      facets: facetOptionShape,
+    })
+  ),
+  /** Categories matched with the facets. */
+  CategoriesTrees: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** Category's name. */
+      Name: PropTypes.string.isRequired,
+      /** Category's quantity. */
+      Quantity: PropTypes.number.isRequired,
+      /** Array of SubCategories. */
+      Children: PropTypes.arrayOf(facetOptionShape),
+    })
+  ),
+})
+
+export const searchQueryShape = PropTypes.shape({
+  /** Products resulting by the search.  */
+  products: PropTypes.arrayOf(productShape),
+})
+
+export const queryShape = PropTypes.shape({
+  /**
+   * Rest of the search term, e.g: eletronics/smartphones/samsung implies that
+   * rest will be equal to "smartphones,samsung".
+   */
+  rest: PropTypes.string,
+  /** Determines the types of the terms, e.g: "c,c,b" (category, category, brand). */
+  map: mapType,
+  /** Search's ordenation. */
+  order: orderType,
+  /** Search's pagination. */
+  page: PropTypes.string,
+})
+
+export const mapType = PropTypes.string
+
+export const orderType = PropTypes.string
+
+export const schemaPropsTypes = {
+  /** Maximum number of items per line. */
+  maxItemsPerLine: PropTypes.number,
+  /** Maximum number of items per page. */
+  maxItemsPerPage: PropTypes.number,
+  /** Product Summary's props */
+  summary: PropTypes.any,
+}

--- a/react/constants/searchSortOptions.js
+++ b/react/constants/searchSortOptions.js
@@ -1,0 +1,30 @@
+export default [
+  {
+    value: 'OrderByTopSaleDESC',
+    label: 'ordenation.sales',
+  },
+  {
+    value: 'OrderByReleaseDateDESC',
+    label: 'ordenation.release.date',
+  },
+  {
+    value: 'OrderByBestDiscountDESC',
+    label: 'ordenation.discount',
+  },
+  {
+    value: 'OrderByPriceDESC',
+    label: 'ordenation.price.descending',
+  },
+  {
+    value: 'OrderByPriceASC',
+    label: 'ordenation.price.ascending',
+  },
+  {
+    value: 'OrderByNameASC',
+    label: 'ordenation.name.ascending',
+  },
+  {
+    value: 'OrderByNameDESC',
+    label: 'ordenation.name.descending',
+  },
+]

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -1,0 +1,124 @@
+import QueryString from 'query-string'
+import * as RouteParser from 'route-parser'
+
+import SortOptions from '../constants/searchSortOptions'
+
+export function joinPathWithRest(path, rest) {
+  let pathValues = stripPath(path).split('/')
+  pathValues = pathValues.concat((rest && rest.split(',')) || [])
+  return pathValues.join('/')
+}
+
+export function getCategoriesFromQuery(query, map) {
+  return getValuesByMap(query, map, 'c')
+}
+
+function getValuesByMap(query, map, mapValue) {
+  const values = query.split('/')
+  const mapValues = map.split(',')
+  const brands = []
+  mapValues.map((value, index) => {
+    if (value === mapValue) {
+      brands.push(values[index])
+    }
+  })
+  return brands
+}
+
+export function findInTree(tree, values, index) {
+  for (let i = 0; i < tree.length; i++) {
+    if (tree[i].Name.toUpperCase() === values[index].toUpperCase()) {
+      if (index === values.length - 1) {
+        return tree[i]
+      }
+      return findInTree(tree[i].Children, values, index + 1)
+    }
+  }
+  return tree[0]
+}
+
+export function createMap(pathName, rest, isBrand) {
+  let pathValues = stripPath(pathName).split('/')
+  if (rest) pathValues = pathValues.concat(rest.split(','))
+  const map =
+    Array(pathValues.length - 1)
+      .fill('c')
+      .join(',') +
+    (pathValues.length > 1 ? ',' : '') +
+    (isBrand ? 'b' : 'c')
+  return map
+}
+
+export function stripPath(pathName) {
+  return pathName
+    .replace(/^\//i, '')
+    .replace(/\/s$/i, '')
+    .replace(/\/d$/i, '')
+    .replace(/\/b$/i, '')
+}
+
+function getPathOfPage(pagesPath) {
+  return global.__RUNTIME__.pages[pagesPath].path
+}
+
+export function reversePagesPath(pagesPath, params) {
+  const Parser = RouteParser.default ? RouteParser.default : RouteParser
+  return new Parser(getPathOfPage(pagesPath)).reverse(params)
+}
+
+function matchPagesPath(pagesPath, pathName) {
+  const Parser = RouteParser.default ? RouteParser.default : RouteParser
+  return new Parser(pagesPath).match(pathName)
+}
+
+function getSpecificationFilterFromLink(link) {
+  return `specificationFilter_${link.split('specificationFilter_')[1]}`
+}
+
+export function getPagesArgs(
+  { name, type, link },
+  pathName,
+  rest,
+  { map, orderBy, pageNumber = 1 },
+  pagesPath,
+  isUnselectLink
+) {
+  const restValues = (rest && rest.split(',')) || []
+  const mapValues = (map && map.split(',')) || []
+  if (name) {
+    if (isUnselectLink) {
+      const pathValuesLength = stripPath(pathName).split('/').length
+      const index = restValues.findIndex(
+        item => name.toLowerCase() === item.toLowerCase()
+      )
+      if (index !== -1) {
+        restValues.splice(index, 1)
+        mapValues.splice(pathValuesLength + index, 1)
+      }
+    } else {
+      switch (type) {
+        case 'Brands': {
+          mapValues.push('b')
+          break
+        }
+        case 'SpecificationFilters': {
+          mapValues.push(`${getSpecificationFilterFromLink(link)}`)
+          break
+        }
+        default: {
+          mapValues.push('c')
+        }
+      }
+      restValues.push(name)
+    }
+  }
+
+  const queryString = QueryString.stringify({
+    map: mapValues.join(','),
+    page: pageNumber !== 1 ? pageNumber : undefined,
+    order: orderBy === SortOptions[0].value ? undefined : orderBy,
+    rest: restValues.join(',') || undefined,
+  })
+  const params = matchPagesPath(getPathOfPage(pagesPath), pathName)
+  return { page: pagesPath, params, queryString }
+}

--- a/react/queries/facetsQuery.gql
+++ b/react/queries/facetsQuery.gql
@@ -1,0 +1,36 @@
+query facets($facets: String) {
+  facets(facets: $facets) {
+    Departments {
+      Quantity
+      Name
+      Link
+    }
+    Brands {
+      Quantity
+      Name
+      Link
+    }
+    SpecificationFilters {
+      name
+      facets {
+        Quantity
+        Name
+        Link
+      }
+    }
+    CategoriesTrees {
+      Quantity
+      Name
+      Children {
+        Quantity
+        Name
+        Link
+        Children {
+          Quantity
+          Name
+          Link
+        }
+      }
+    }
+  }
+}

--- a/react/queries/searchQuery.gql
+++ b/react/queries/searchQuery.gql
@@ -1,0 +1,45 @@
+query search($query: String, $map: String, $orderBy: String, $from: Int, $to: Int) {
+  products(query:$query, map: $map, orderBy: $orderBy, from: $from, to: $to) {
+    productId
+    productName
+    linkText
+    description
+    brand
+    link
+    items {
+      itemId
+      name
+      nameComplete
+      complementName
+      ean
+      referenceId {
+        Key
+        Value
+      }
+      measurementUnit
+      unitMultiplier
+      images {
+        imageId
+        imageLabel
+        imageTag
+        imageUrl
+        imageText
+      }
+      sellers {
+        sellerId
+        sellerName
+        commertialOffer {
+          Price
+          ListPrice
+          PriceWithoutDiscount
+          RewardValue
+          PriceValidUntil
+          AvailableQuantity
+        }
+      }
+    }
+    productClusters {
+      name
+    }
+  }
+}

--- a/react/queries/searchResultQuery.gql
+++ b/react/queries/searchResultQuery.gql
@@ -1,3 +1,0 @@
-query searchResult {
-  maxItemsPerPage @client
-}

--- a/react/queries/searchResultQuery.gql
+++ b/react/queries/searchResultQuery.gql
@@ -1,0 +1,3 @@
+query searchResult {
+  maxItemsPerPage @client
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the SearchResult's GraphQL queries to the project so the data layer can get them.

#### What problem is this solving?

Lack of information to populate the data layer

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/eletronics/s)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/42246009-683e73fe-7ef1-11e8-8499-30825e1616fa.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
