### PR TITLE
Add the DepartmentPage component and fix search loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the `DepartmentPage` component.
+
+### Fixed
+- Fix loading logic inside the `SearchQueryContainer`.
 
 ## [0.5.0] - 2018-7-5
 ### Added

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -69,7 +69,7 @@
       "component": "vtex.render-runtime/ExtensionContainer"
     },
     "store/department": {
-      "component": "CategoryPage"
+      "component": "DepartmentPage"
     },
     "store/department/container": {
       "component": "vtex.render-runtime/ExtensionContainer"

--- a/react/DepartmentPage.js
+++ b/react/DepartmentPage.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { ExtensionPoint } from 'render'
+
+import SearchQueryContainer from './components/SearchQueryContainer'
+import { searchQueryPropTypes } from './constants/propTypes'
+import { SearchQueryContext } from './constants/searchContext'
+
+export default class DepartmentPage extends Component {
+  static contextTypes = {
+    prefetchPage: PropTypes.func,
+  }
+
+  static propTypes = {
+    /** Query params */
+    params: PropTypes.shape({
+      /** Department param */
+      department: PropTypes.string.isRequired,
+    }),
+    ...searchQueryPropTypes,
+  }
+
+  componentDidMount() {
+    this.context.prefetchPage('store/home')
+  }
+
+  render() {
+    return (
+      <SearchQueryContainer {...this.props}>
+        <SearchQueryContext.Consumer>
+          {contextProps => <ExtensionPoint id="container" {...contextProps} />}
+        </SearchQueryContext.Consumer>
+      </SearchQueryContainer>
+    )
+  }
+}

--- a/react/components/SearchQueryContainer.js
+++ b/react/components/SearchQueryContainer.js
@@ -15,6 +15,8 @@ const DEFAULT_MAX_ITEMS_PER_PAGE = 1
 class SearchQueryContainer extends Component {
   state = {
     maxItemsPerPage: DEFAULT_MAX_ITEMS_PER_PAGE,
+    /* Will be loading by default. The container will wait until the real data arrives */
+    loading: true,
   }
 
   static propTypes = {
@@ -65,7 +67,12 @@ class SearchQueryContainer extends Component {
                 value={{
                   state: {
                     ...this.state,
-                    setContextVariables: variables => this.setState(variables),
+                    setContextVariables: variables =>
+                      this.setState({
+                        ...variables,
+                        /* When the real data arrives, isn't loading anymore */
+                        loading: false,
+                      }),
                   },
                   ...contextProps,
                   searchQuery: {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the `DepartmentPage` component and fix search loading logic inside the `SearchQueryContainer` component.

#### What problem is this solving?

1. There was no `DepartmentPage`
2. There was no way to know if the query result was the first one or the real data one.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/eletronics/d)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/42339956-03d0df36-8065-11e8-80b4-1c44c4d53bce.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
