### PR TITLE
add hints to the end of category or subcategory paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add a generic component (`SearchQueryContainer`) to be reused into the different pages that uses search and facets queries.
+- Add hints to the end of category and subcategory paths
 
 ## [0.4.1] - 2018-7-4
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.0] - 2018-7-5
 ### Added
 - Add a generic component (`SearchQueryContainer`) to be reused into the different pages that uses search and facets queries.
 - Add hints to the end of category and subcategory paths

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -25,10 +25,10 @@
       "path": "/:department/d"
     },
     "store/category": {
-      "path": "/:department/:category"
+      "path": "/:department/:category/c"
     },
     "store/subcategory": {
-      "path": "/:department/:category/:subcategory"
+      "path": "/:department/:category/:subcategory/sc"
     },
     "store/search": {
       "path": "/:term/s"


### PR DESCRIPTION
We had a serious problem yesterday.

Routes like: `/api/billing/contracts` were being served by render-server due to paths like `/:department/:category/:subcategory` in which nothing is "fixed". 

It should be rendered by colossus-legacy-proxy (which is the last possible match)

By adding a hint to the end of the url we can prevent this behavior.