### PR TITLE
Fix path error in non-linked app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix path error in non-linked app by adding a default path in case there isn't any.
 
 ## [0.7.0] - 2018-7-6
 ### Changed

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -58,12 +58,15 @@ export function stripPath(pathName) {
 }
 
 function getPathOfPage(pagesPath) {
-  return global.__RUNTIME__.pages[pagesPath].path
+  return (
+    global.__RUNTIME__.pages[pagesPath] &&
+    global.__RUNTIME__.pages[pagesPath].path
+  )
 }
 
 export function reversePagesPath(pagesPath, params) {
   const Parser = RouteParser.default ? RouteParser.default : RouteParser
-  return new Parser(getPathOfPage(pagesPath)).reverse(params)
+  return new Parser(getPathOfPage(pagesPath) || '').reverse(params)
 }
 
 function matchPagesPath(pagesPath, pathName) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix path error in non-linked app by adding a default path in case there isn't any.

#### What problem is this solving?

Undefined page when the store is not linked.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/vehicles/d)

#### Screenshots or example usage

Before...

![image](https://user-images.githubusercontent.com/15948386/42448596-07e3d2c6-8354-11e8-8d16-0884def48695.png)



#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
