### PR TITLE
Fix path value inside the SearchQueryContainer component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix path value inside the `SearchQueryContainer` component.
 
 ## [0.7.1] - 2018-7-9
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.7.2] - 2018-7-9
 ### Fixed
 - Fix path value inside the `SearchQueryContainer` component.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/react/components/SearchQueryContainer.js
+++ b/react/components/SearchQueryContainer.js
@@ -37,7 +37,7 @@ class SearchQueryContainer extends Component {
       },
     } = this.props
 
-    const path = reversePagesPath(treePath, params)
+    const path = reversePagesPath(treePath, params) || ''
     const map = mapProps || createMap(path, rest)
     const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE
     const query = joinPathWithRest(path, rest)

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -49,7 +49,7 @@ export function createMap(pathName, rest, isBrand) {
   return map
 }
 
-export function stripPath(pathName) {
+export function stripPath(pathName = '') {
   return pathName
     .replace(/^\//i, '')
     .replace(/\/s$/i, '')


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix path value inside the `SearchQueryContainer` component. The default path value added in the previous PR didn't solve all `undefined` values problems.

#### What problem is this solving?

Undefined path value after reverse params.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/vehicles/d)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/42450734-8301808c-835b-11e8-8759-01188c111e57.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
