### PR TITLE
Change reverse path evaluation to not use pages.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- Change reverse path evaluation to not use pages.json
+
 ### Fixed
 - Fix pages params evaluation.
 

--- a/react/components/SearchQueryContainer.js
+++ b/react/components/SearchQueryContainer.js
@@ -29,7 +29,6 @@ class SearchQueryContainer extends Component {
     const {
       treePath,
       params,
-      runtime,
       query: {
         order: orderBy = SortOptions[0].value,
         page: pageProps,
@@ -38,7 +37,7 @@ class SearchQueryContainer extends Component {
       },
     } = this.props
 
-    const path = reversePagesPath(runtime, treePath, params)
+    const path = reversePagesPath(treePath, params)
     const map = mapProps || createMap(path, rest)
     const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE
     const query = joinPathWithRest(path, rest)

--- a/react/components/SearchQueryContainer.js
+++ b/react/components/SearchQueryContainer.js
@@ -20,6 +20,19 @@ class SearchQueryContainer extends Component {
   }
 
   static propTypes = {
+    /** Query params */
+    params: PropTypes.shape({
+      /** Department param */
+      department: PropTypes.string,
+      /** Brand name */
+      brand: PropTypes.string,
+      /** Search's term, e.g: eletronics. */
+      term: PropTypes.string,
+      /** Category param */
+      category: PropTypes.string,
+      /** Subcategory param */
+      subcategory: PropTypes.string,
+    }),
     ...searchQueryPropTypes,
     /** Children to be rendered */
     children: PropTypes.node.isRequired,

--- a/react/components/SearchQueryContainer.js
+++ b/react/components/SearchQueryContainer.js
@@ -29,6 +29,7 @@ class SearchQueryContainer extends Component {
     const {
       treePath,
       params,
+      runtime,
       query: {
         order: orderBy = SortOptions[0].value,
         page: pageProps,
@@ -37,7 +38,7 @@ class SearchQueryContainer extends Component {
       },
     } = this.props
 
-    const path = reversePagesPath(treePath, params)
+    const path = reversePagesPath(runtime, treePath, params)
     const map = mapProps || createMap(path, rest)
     const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE
     const query = joinPathWithRest(path, rest)

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -140,6 +140,8 @@ export const searchQueryPropTypes = {
   }),
   /** Internal route path. e.g: 'store/search' */
   treePath: PropTypes.string,
+  /** App runtime */
+  runtime: PropTypes.object,
   /** Facets graphql query. */
   facetsQuery: facetsQueryShape,
   /** Search graphql query. */

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -140,8 +140,6 @@ export const searchQueryPropTypes = {
   }),
   /** Internal route path. e.g: 'store/search' */
   treePath: PropTypes.string,
-  /** App runtime */
-  runtime: PropTypes.object,
   /** Facets graphql query. */
   facetsQuery: facetsQueryShape,
   /** Search graphql query. */

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -1,7 +1,5 @@
 import * as RouteParser from 'route-parser'
 
-import pagesJson from '../../pages/pages.json'
-
 export function joinPathWithRest(path, rest) {
   let pathValues = stripPath(path).split('/')
   pathValues = pathValues.concat((rest && rest.split(',')) || [])
@@ -56,7 +54,68 @@ export function stripPath(pathName) {
     .replace(/\/b$/i, '')
 }
 
-export function reversePagesPath(pagesPath, params) {
+function getPathOfPage(runtime, pagesPath) {
+  return runtime && runtime.pages[pagesPath] && runtime.pages[pagesPath].path
+}
+
+export function reversePagesPath(runtime, pagesPath, params) {
   const Parser = RouteParser.default ? RouteParser.default : RouteParser
-  return new Parser(pagesJson.pages[pagesPath].path || '').reverse(params)
+  return new Parser(getPathOfPage(runtime, pagesPath) || '').reverse(params)
+}
+
+function matchPagesPath(pagesPath, pathName) {
+  const Parser = RouteParser.default ? RouteParser.default : RouteParser
+  return new Parser(pagesPath).match(pathName)
+}
+
+function getSpecificationFilterFromLink(link) {
+  return `specificationFilter_${link.split('specificationFilter_')[1]}`
+}
+
+export function getPagesArgs(
+  { name, type, link },
+  pathName,
+  rest,
+  { map, orderBy, pageNumber = 1 },
+  pagesPath,
+  isUnselectLink
+) {
+  const restValues = (rest && rest.split(',')) || []
+  const mapValues = (map && map.split(',')) || []
+  if (name) {
+    if (isUnselectLink) {
+      const pathValuesLength = stripPath(pathName).split('/').length
+      const index = restValues.findIndex(
+        item => name.toLowerCase() === item.toLowerCase()
+      )
+      if (index !== -1) {
+        restValues.splice(index, 1)
+        mapValues.splice(pathValuesLength + index, 1)
+      }
+    } else {
+      switch (type) {
+        case 'Brands': {
+          mapValues.push('b')
+          break
+        }
+        case 'SpecificationFilters': {
+          mapValues.push(`${getSpecificationFilterFromLink(link)}`)
+          break
+        }
+        default: {
+          mapValues.push('c')
+        }
+      }
+      restValues.push(name)
+    }
+  }
+
+  const queryString = QueryString.stringify({
+    map: mapValues.join(','),
+    page: pageNumber !== 1 ? pageNumber : undefined,
+    order: orderBy === SortOptions[0].value ? undefined : orderBy,
+    rest: restValues.join(',') || undefined,
+  })
+  const params = matchPagesPath(getPathOfPage(pagesPath), pathName)
+  return { page: pagesPath, params, queryString }
 }

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -56,11 +56,7 @@ export function stripPath(pathName) {
     .replace(/\/b$/i, '')
 }
 
-function getPathOfPage(pagesPath) {
-  return pagesJson.pages[pagesPath].path
-}
-
 export function reversePagesPath(pagesPath, params) {
   const Parser = RouteParser.default ? RouteParser.default : RouteParser
-  return new Parser(getPathOfPage(pagesPath) || '').reverse(params)
+  return new Parser(pagesJson.pages[pagesPath].path || '').reverse(params)
 }

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -1,5 +1,7 @@
 import * as RouteParser from 'route-parser'
 
+import pagesJson from '../../pages/pages.json'
+
 export function joinPathWithRest(path, rest) {
   let pathValues = stripPath(path).split('/')
   pathValues = pathValues.concat((rest && rest.split(',')) || [])
@@ -55,8 +57,7 @@ export function stripPath(pathName) {
 }
 
 function getPathOfPage(pagesPath) {
-  const pages = require('../../pages/pages.json')
-  return pages.pages[pagesPath].path
+  return pagesJson.pages[pagesPath].path
 }
 
 export function reversePagesPath(pagesPath, params) {

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -1,5 +1,3 @@
-import * as RouteParser from 'route-parser'
-
 export function joinPathWithRest(path, rest) {
   let pathValues = stripPath(path).split('/')
   pathValues = pathValues.concat((rest && rest.split(',')) || [])
@@ -54,68 +52,17 @@ export function stripPath(pathName) {
     .replace(/\/b$/i, '')
 }
 
-function getPathOfPage(runtime, pagesPath) {
-  return runtime && runtime.pages[pagesPath] && runtime.pages[pagesPath].path
-}
-
-export function reversePagesPath(runtime, pagesPath, params) {
-  const Parser = RouteParser.default ? RouteParser.default : RouteParser
-  return new Parser(getPathOfPage(runtime, pagesPath) || '').reverse(params)
-}
-
-function matchPagesPath(pagesPath, pathName) {
-  const Parser = RouteParser.default ? RouteParser.default : RouteParser
-  return new Parser(pagesPath).match(pathName)
-}
-
-function getSpecificationFilterFromLink(link) {
-  return `specificationFilter_${link.split('specificationFilter_')[1]}`
-}
-
-export function getPagesArgs(
-  { name, type, link },
-  pathName,
-  rest,
-  { map, orderBy, pageNumber = 1 },
-  pagesPath,
-  isUnselectLink
-) {
-  const restValues = (rest && rest.split(',')) || []
-  const mapValues = (map && map.split(',')) || []
-  if (name) {
-    if (isUnselectLink) {
-      const pathValuesLength = stripPath(pathName).split('/').length
-      const index = restValues.findIndex(
-        item => name.toLowerCase() === item.toLowerCase()
-      )
-      if (index !== -1) {
-        restValues.splice(index, 1)
-        mapValues.splice(pathValuesLength + index, 1)
-      }
-    } else {
-      switch (type) {
-        case 'Brands': {
-          mapValues.push('b')
-          break
-        }
-        case 'SpecificationFilters': {
-          mapValues.push(`${getSpecificationFilterFromLink(link)}`)
-          break
-        }
-        default: {
-          mapValues.push('c')
-        }
-      }
-      restValues.push(name)
-    }
+export function reversePagesPath(pagesPath, params) {
+  switch (pagesPath) {
+    case 'store/search':
+      return `/${params.term}`
+    case 'store/department':
+      return `/${params.department}`
+    case 'store/category':
+      return `/${params.department}/${params.category}`
+    case 'store/subcategory':
+      return `/${params.department}/${params.category}/${params.subcategory}`
+    default:
+      return '/'
   }
-
-  const queryString = QueryString.stringify({
-    map: mapValues.join(','),
-    page: pageNumber !== 1 ? pageNumber : undefined,
-    order: orderBy === SortOptions[0].value ? undefined : orderBy,
-    rest: restValues.join(',') || undefined,
-  })
-  const params = matchPagesPath(getPathOfPage(pagesPath), pathName)
-  return { page: pagesPath, params, queryString }
 }

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -1,3 +1,5 @@
+import * as RouteParser from 'route-parser'
+
 export function joinPathWithRest(path, rest) {
   let pathValues = stripPath(path).split('/')
   pathValues = pathValues.concat((rest && rest.split(',')) || [])
@@ -52,17 +54,12 @@ export function stripPath(pathName) {
     .replace(/\/b$/i, '')
 }
 
+function getPathOfPage(pagesPath) {
+  const pages = require('../../pages/pages.json')
+  return pages.pages[pagesPath].path
+}
+
 export function reversePagesPath(pagesPath, params) {
-  switch (pagesPath) {
-    case 'store/search':
-      return `/${params.term}`
-    case 'store/department':
-      return `/${params.department}`
-    case 'store/category':
-      return `/${params.department}/${params.category}`
-    case 'store/subcategory':
-      return `/${params.department}/${params.category}/${params.subcategory}`
-    default:
-      return '/'
-  }
+  const Parser = RouteParser.default ? RouteParser.default : RouteParser
+  return new Parser(getPathOfPage(pagesPath) || '').reverse(params)
 }

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -1,7 +1,3 @@
-import * as RouteParser from 'route-parser'
-
-import pagesJson from '../../pages/pages.json'
-
 export function joinPathWithRest(path, rest) {
   let pathValues = stripPath(path).split('/')
   pathValues = pathValues.concat((rest && rest.split(',')) || [])
@@ -57,6 +53,16 @@ export function stripPath(pathName) {
 }
 
 export function reversePagesPath(pagesPath, params) {
-  const Parser = RouteParser.default ? RouteParser.default : RouteParser
-  return new Parser(pagesJson.pages[pagesPath].path || '').reverse(params)
+  switch (pagesPath) {
+    case 'store/search':
+      return `/${params.term}`
+    case 'store/department':
+      return `/${params.department}`
+    case 'store/category':
+      return `/${params.department}/${params.category}`
+    case 'store/subcategory':
+      return `/${params.department}/${params.category}/${params.subcategory}`
+    default:
+      return '/'
+  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change reverse path evaluation to not use pages.json

#### What problem is this solving?

Helper was using pages.json

#### How should this be manually tested?
[Access the workspace](https://estacio--storecomponents.myvtex.com/eletronics/d)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/42639835-5a5b2aca-85c7-11e8-8fb0-ed1a2df5254a.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
