### PR TITLE
Fix params evaluation when there is no page path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix params evaluation when there is no page path.
 
 ## [0.8.1] - 2018-07-12
 ## Changed

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -52,7 +52,22 @@ export function stripPath(pathName) {
     .replace(/\/b$/i, '')
 }
 
+function getPathByParams(params) {
+  if (params.term) return `/${params.term}`
+  if (params.department && params.category && params.subcategory) {
+    return `/${params.department}/${params.category}/${params.subcategory}`
+  }
+  if (params.department && params.category) {
+    return `/${params.department}/${params.category}`
+  }
+  if (params.department) return `/${params.department}`
+  return '/'
+}
+
 export function reversePagesPath(pagesPath, params) {
+  if (!pagesPath) {
+    return getPathByParams(params)
+  }
   switch (pagesPath) {
     case 'store/search':
       return `/${params.term}`


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix params evaluation when there is no page path.

#### What problem is this solving?

`treePath` is not being passed to the `ExtensionComponent`, so we need to be able to evaluate the page without the `treePath` and use only the `params`

#### How should this be manually tested?

[Accessing the workspace](https://estacio--storecomponents.myvtex.com/vehicles/d)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/42702413-d483ee62-869f-11e8-909d-d26d05244fa0.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
