### PR TITLE
Data layer integration in the ProductSearchContextProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.2.0] - 2018-07-23
 ### Added
 - Data layer integration in the `ProductSearchContextProvider`.
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Data layer integration in the `ProductSearchContextProvider`.
+### Fixed
+- Fix the `searchHelpers.reversePagesPath` function to return the full path.
 
 ## [1.1.3] - 2018-07-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Data layer integration in the `ProductSearchContextProvider`.
 
 ## [1.1.3] - 2018-07-18
 ### Fixed
@@ -70,7 +72,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add `MicroData` component do `ProductPage`, so Google can have a detailed info on the Products.
 - Add the `SearchPage` GraphQL queries.
-- Data layer intergration in the `ProductPage`.
+- Data layer integration in the `ProductPage`.
 
 ## [0.4.0-beta] - 2018-7-3
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -1,49 +1,16 @@
-import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import { graphql, compose } from 'react-apollo'
-import MicroData from './components/MicroData'
+import React, { Component, Fragment } from 'react'
+import { compose, graphql } from 'react-apollo'
 
-import withDataLayer, { dataLayerProps } from './components/withDataLayer'
+import MicroData from './components/MicroData'
+import ProductDataLayer from './components/ProductDataLayer'
 import productQuery from './queries/productQuery.gql'
 
 class ProductContextProvider extends Component {
   static propTypes = {
     params: PropTypes.object,
     data: PropTypes.object,
-    ...dataLayerProps,
-  }
-
-  pushToDataLayer = product => {
-    this.props.pushToDataLayer({
-      event: 'productDetail',
-      ecommerce: {
-        detail: {
-          products: [
-            {
-              name: product.productName,
-              brand: product.brand,
-              category:
-                product.categories.length > 0
-                  ? product.categories[0]
-                  : undefined,
-              id: product.productId,
-            },
-          ],
-        },
-      },
-    })
-  }
-
-  componentDidMount() {
-    if (!this.props.data.loading) {
-      this.pushToDataLayer(this.props.data.product)
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.data.loading && !this.props.data.loading) {
-      this.pushToDataLayer(this.props.data.product)
-    }
+    children: PropTypes.node,
   }
 
   render() {
@@ -63,11 +30,13 @@ class ProductContextProvider extends Component {
       <div className="vtex-product-details-container">
         <Fragment>
           {!loading && <MicroData product={product} />}
-          {React.cloneElement(this.props.children, {
-            productQuery,
-            categories,
-            slug,
-          })}
+          <ProductDataLayer data={this.props.data}>
+            {React.cloneElement(this.props.children, {
+              productQuery,
+              categories,
+              slug,
+            })}
+          </ProductDataLayer>
         </Fragment>
       </div>
     )
@@ -82,7 +51,4 @@ const options = {
   }),
 }
 
-export default compose(
-  graphql(productQuery, options),
-  withDataLayer
-)(ProductContextProvider)
+export default compose(graphql(productQuery, options))(ProductContextProvider)

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
+import ProductSearchDataLayer from './components/ProductSearchDataLayer'
 import SearchQueryContainer from './components/SearchQueryContainer'
 import { searchQueryPropTypes } from './constants/propTypes'
 import { SearchQueryContext } from './constants/searchContext'
@@ -28,18 +29,22 @@ class ProductSearchContextProvider extends Component {
     const props = {
       ...this.props,
       // todo: this logic should be in SearchQueryContainer
-      ...this.props.params.brand && {
+      ...(this.props.params.brand && {
         query: {
           ...this.props.query,
           map: this.props.map || 'b',
-        }
-      }
+        },
+      }),
     }
 
     return (
       <SearchQueryContainer {...props}>
         <SearchQueryContext.Consumer>
-          {contextProps => React.cloneElement(this.props.children, contextProps)}
+          {contextProps => (
+            <ProductSearchDataLayer searchQuery={contextProps.searchQuery}>
+              {React.cloneElement(this.props.children, contextProps)}
+            </ProductSearchDataLayer>
+          )}
         </SearchQueryContext.Consumer>
       </SearchQueryContainer>
     )

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -41,7 +41,11 @@ class ProductSearchContextProvider extends Component {
       <SearchQueryContainer {...props}>
         <SearchQueryContext.Consumer>
           {contextProps => (
-            <ProductSearchDataLayer searchQuery={contextProps.searchQuery}>
+            <ProductSearchDataLayer
+              searchQuery={contextProps.searchQuery}
+              loading={
+                contextProps.state.loading || contextProps.searchQuery.loading
+              }>
               {React.cloneElement(this.props.children, contextProps)}
             </ProductSearchDataLayer>
           )}

--- a/react/components/DataLayerWrapper.js
+++ b/react/components/DataLayerWrapper.js
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types'
+import { Component } from 'react'
+
+import withDataLayer, { dataLayerProps } from './withDataLayer'
+
+class DataLayerWrapper extends Component {
+  static propTypes = {
+    /** Data to be pushed to the data layer. */
+    data: PropTypes.object.isRequired,
+    /** Loading information */
+    loading: PropTypes.bool.isRequired,
+    /** Function to format the data according to the data layer */
+    formatToDataLayer: PropTypes.func.isRequired,
+    /** Children nodes */
+    children: PropTypes.node.isRequired,
+    ...dataLayerProps,
+  }
+
+  pushToDataLayer = data => {
+    this.props.pushToDataLayer(this.props.formatToDataLayer(data))
+  }
+
+  componentDidMount() {
+    if (!this.props.loading) {
+      this.pushToDataLayer(this.props.data)
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.loading && !this.props.loading) {
+      this.pushToDataLayer(this.props.data)
+    }
+  }
+
+  render() {
+    return this.props.children
+  }
+}
+
+export default withDataLayer(DataLayerWrapper)

--- a/react/components/ProductDataLayer.js
+++ b/react/components/ProductDataLayer.js
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import { getProductDetail } from '../helpers/dataLayerHelper'
+import DataLayerWrapper from './DataLayerWrapper'
+import withDataLayer, { dataLayerProps } from './withDataLayer'
+
+class ProductDataLayer extends Component {
+  static propTypes = {
+    /** Product graphql query. */
+    data: PropTypes.object.isRequired,
+    /** Children nodes */
+    children: PropTypes.node.isRequired,
+    ...dataLayerProps,
+  }
+
+  formatToDataLayer = product => ({
+    ecommerce: {
+      detail: {
+        products: [getProductDetail(product)],
+      },
+    },
+  })
+
+  render() {
+    return (
+      <DataLayerWrapper
+        data={this.props.data.product}
+        loading={this.props.data.loading}
+        formatToDataLayer={this.formatToDataLayer}>
+        {this.props.children}
+      </DataLayerWrapper>
+    )
+  }
+}
+
+export default withDataLayer(ProductDataLayer)

--- a/react/components/ProductSearchDataLayer.js
+++ b/react/components/ProductSearchDataLayer.js
@@ -25,13 +25,13 @@ class ProductSearchDataLayer extends Component {
   }
 
   componentDidMount() {
-    if (!this.props.searchQuery.loading) {
+    if (!this.props.loading) {
       this.pushToDataLayer(this.props.searchQuery.products)
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.searchQuery.loading && !this.props.searchQuery.loading) {
+    if (prevProps.loading && !this.props.loading) {
       this.pushToDataLayer(this.props.searchQuery.products)
     }
   }

--- a/react/components/ProductSearchDataLayer.js
+++ b/react/components/ProductSearchDataLayer.js
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types'
+import { Component } from 'react'
+
+import { searchQueryShape } from '../constants/propTypes'
+import { getProductImpression } from '../helpers/dataLayerHelper'
+import withDataLayer, { dataLayerProps } from './withDataLayer'
+
+class ProductSearchDataLayer extends Component {
+  static propTypes = {
+    /** Search graphql query. */
+    searchQuery: searchQueryShape,
+    /** Children nodes */
+    children: PropTypes.node.isRequired,
+    ...dataLayerProps,
+  }
+
+  pushToDataLayer = products => {
+    this.props.pushToDataLayer({
+      ecommerce: {
+        impressions: products.map((product, index) =>
+          getProductImpression(product, { position: index + 1 })
+        ),
+      },
+    })
+  }
+
+  componentDidMount() {
+    if (!this.props.searchQuery.loading) {
+      this.pushToDataLayer(this.props.searchQuery.products)
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.searchQuery.loading && !this.props.searchQuery.loading) {
+      this.pushToDataLayer(this.props.searchQuery.products)
+    }
+  }
+
+  render() {
+    return this.props.children
+  }
+}
+
+export default withDataLayer(ProductSearchDataLayer)

--- a/react/components/ProductSearchDataLayer.js
+++ b/react/components/ProductSearchDataLayer.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types'
-import { Component } from 'react'
+import React, { Component } from 'react'
 
 import { searchQueryShape } from '../constants/propTypes'
 import { getProductImpression } from '../helpers/dataLayerHelper'
+import DataLayerWrapper from './DataLayerWrapper'
 import withDataLayer, { dataLayerProps } from './withDataLayer'
 
 class ProductSearchDataLayer extends Component {
@@ -14,30 +15,23 @@ class ProductSearchDataLayer extends Component {
     ...dataLayerProps,
   }
 
-  pushToDataLayer = products => {
-    this.props.pushToDataLayer({
-      ecommerce: {
-        impressions: products.map((product, index) =>
-          getProductImpression(product, { position: index + 1 })
-        ),
-      },
-    })
-  }
-
-  componentDidMount() {
-    if (!this.props.loading) {
-      this.pushToDataLayer(this.props.searchQuery.products)
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.loading && !this.props.loading) {
-      this.pushToDataLayer(this.props.searchQuery.products)
-    }
-  }
+  formatToDataLayer = products => ({
+    ecommerce: {
+      impressions: products.map((product, index) =>
+        getProductImpression(product, { position: index + 1 })
+      ),
+    },
+  })
 
   render() {
-    return this.props.children
+    return (
+      <DataLayerWrapper
+        data={this.props.searchQuery.products}
+        loading={this.props.searchQuery.loading}
+        formatToDataLayer={this.formatToDataLayer}>
+        {this.props.children}
+      </DataLayerWrapper>
+    )
   }
 }
 

--- a/react/components/SearchQueryContainer.js
+++ b/react/components/SearchQueryContainer.js
@@ -96,6 +96,10 @@ class SearchQueryContainer extends Component {
                     ...facetsQueryProps,
                     ...facetsQueryProps.data,
                   },
+                  loading:
+                    this.state.loading ||
+                    searchQuery.loading ||
+                    facetsQuery.loading,
                 }}>
                 {this.props.children}
               </SearchQueryContext.Provider>

--- a/react/components/SearchQueryContainer.js
+++ b/react/components/SearchQueryContainer.js
@@ -96,10 +96,6 @@ class SearchQueryContainer extends Component {
                     ...facetsQueryProps,
                     ...facetsQueryProps.data,
                   },
-                  loading:
-                    this.state.loading ||
-                    searchQuery.loading ||
-                    facetsQuery.loading,
                 }}>
                 {this.props.children}
               </SearchQueryContext.Provider>

--- a/react/helpers/dataLayerHelper.js
+++ b/react/helpers/dataLayerHelper.js
@@ -1,0 +1,12 @@
+import { path } from 'ramda'
+
+export function getProductImpression(product, customProps = {}) {
+  return {
+    id: product.productId,
+    name: product.productName,
+    list: 'Search Results',
+    brand: product.brand,
+    category: path(['categories', '0'], product),
+    ...customProps,
+  }
+}

--- a/react/helpers/dataLayerHelper.js
+++ b/react/helpers/dataLayerHelper.js
@@ -10,3 +10,13 @@ export function getProductImpression(product, customProps = {}) {
     ...customProps,
   }
 }
+
+export function getProductDetail(product, customProps = {}) {
+  return {
+    id: product.productId,
+    name: product.productName,
+    brand: product.brand,
+    category: path(['categories', '0'], product),
+    ...customProps,
+  }
+}

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -53,18 +53,18 @@ export function stripPath(pathName) {
 }
 
 export function reversePagesPath(params) {
-  if (params.term) return `/${params.term}`
+  if (params.term) return `/${params.term}/s`
 
   if (params.department && params.category && params.subcategory) {
-    return `/${params.department}/${params.category}/${params.subcategory}`
+    return `/${params.department}/${params.category}/${params.subcategory}/sc`
   }
 
   if (params.department && params.category) {
-    return `/${params.department}/${params.category}`
+    return `/${params.department}/${params.category}/c`
   }
 
   if (params.department) {
-    return `/${params.department}`
+    return `/${params.department}/d`
   }
 
   return '/'


### PR DESCRIPTION
#### What is the purpose of this pull request?

Data layer integration in the `ProductSearchContextProvider` and fix the `searchHelpers.reversePagesPath` function to return the full path.

#### What problem is this solving?

There was data layer integration only in the `ProductContextProvider` and the `searchHelpers.reversePagesPath` function was returning invalid values to be used inside the `vtex.search-result/SearchResult`

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/eletronics/d)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/42908223-b9805874-8ab6-11e8-857c-749fc66e9abb.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
