### PR TITLE
Update product query (change property product to benefitProduct)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Property name of productQuery benefits.items.product to benefits.items.benefitProduct
 
 ## [0.8.1] - 2018-07-12
-## Changed
+### Changed
 - Change reverse path evaluation to not use pages.json
 
 ### Fixed

--- a/react/queries/productQuery.gql
+++ b/react/queries/productQuery.gql
@@ -56,7 +56,7 @@ query Product($slug: String) {
       id
       name
       items {
-        product {
+        benefitProduct {
 					productName
           productId
           description


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Changed Property name of productQuery benefits.items.product to benefits.items.benefitProduct

#### What problem is this solving?
- When executing the query Product with the attribute benefits.items.product, cause a circular request query.

#### How should this be manually tested?
[workspace](https://claudivan--storecomponents.myvtex.com)

1 - Go to Home Page
2 - Click in a product, the Product Page must be rendered without errors

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
