### PR TITLE
Delete all unnecessary path manipulation to not need pages information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Delete all unecessary path manipulation to not need pages information.
 
 ## [1.3.1] - 2018-07-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.3.2] - 2018-07-25
 ### Changed
 - Delete all unnecessary path manipulation to not need pages information.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Delete all unecessary path manipulation to not need pages information.
+- Delete all unnecessary path manipulation to not need pages information.
 
 ## [1.3.1] - 2018-07-24
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/react/components/SearchQueryContainer.js
+++ b/react/components/SearchQueryContainer.js
@@ -4,7 +4,7 @@ import { Query } from 'react-apollo'
 import { searchContextPropTypes } from '../constants/propTypes'
 import { SearchQueryContext } from '../constants/searchContext'
 import SortOptions from '../constants/searchSortOptions'
-import { createMap, reversePagesPath, stripPath } from '../helpers/searchHelpers'
+import { createMap } from '../helpers/searchHelpers'
 import searchQuery from '../queries/searchQuery.gql'
 
 const DEFAULT_PAGE = 1
@@ -31,15 +31,13 @@ class SearchQueryContainer extends Component {
       },
     } = this.props
 
-    const path = reversePagesPath(params)
-    const map = mapProps || createMap(path, rest)
+    const map = mapProps || createMap(params, rest)
     const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE
     const from = (page - 1) * this.state.maxItemsPerPage
     const to = from + this.state.maxItemsPerPage - 1
 
     const contextProps = {
       ...this.props,
-      path,
       map,
       rest,
       page,
@@ -50,7 +48,14 @@ class SearchQueryContainer extends Component {
     return (
       <Query
         query={searchQuery}
-        variables={{ query: stripPath(path), map, rest, orderBy, from, to }}
+        variables={{
+          query: Object.values(params).join('/'),
+          map,
+          rest,
+          orderBy,
+          from,
+          to,
+        }}
         notifyOnNetworkStatusChange>
         {searchQueryProps => (
           <SearchQueryContext.Provider

--- a/react/helpers/searchHelpers.js
+++ b/react/helpers/searchHelpers.js
@@ -1,53 +1,13 @@
-export function getCategoriesFromQuery(query, map) {
-  return getValuesByMap(query, map, 'c')
-}
-
-function getValuesByMap(query, map, mapValue) {
-  const values = query.split('/')
-  const mapValues = map.split(',')
-  const brands = []
-  mapValues.map((value, index) => {
-    if (value === mapValue) {
-      brands.push(values[index])
-    }
-  })
-  return brands
-}
-
-export function createMap(pathName, rest, isBrand) {
-  let pathValues = stripPath(pathName).split('/')
-  if (rest) pathValues = pathValues.concat(rest.split(','))
+export function createMap(params, rest, isBrand) {
+  const paramValues = Object.keys(params)
+    .filter(param => !param.startsWith('_'))
+    .map(key => params[key])
+    .concat(rest ? rest.split(',') : [])
   const map =
-    Array(pathValues.length - 1)
+    Array(paramValues.length - 1)
       .fill('c')
       .join(',') +
-    (pathValues.length > 1 ? ',' : '') +
+    (paramValues.length > 1 ? ',' : '') +
     (isBrand ? 'b' : 'c')
   return map
-}
-
-export function stripPath(pathName) {
-  return pathName
-    .replace(/^\//i, '')
-    .replace(/\/s$/i, '')
-    .replace(/\/d$/i, '')
-    .replace(/\/b$/i, '')
-}
-
-export function reversePagesPath(params) {
-  if (params.term) return `/${params.term}/s`
-
-  if (params.department && params.category && params.subcategory) {
-    return `/${params.department}/${params.category}/${params.subcategory}/sc`
-  }
-
-  if (params.department && params.category) {
-    return `/${params.department}/${params.category}/c`
-  }
-
-  if (params.department) {
-    return `/${params.department}/d`
-  }
-
-  return '/'
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Delete all unnecessary path manipulation to not need pages information.

#### What problem is this solving?

Before this, there was some pages information inside the search helpers.

#### How should this be manually tested?
[Access the workspace](https://estacio--storecomponents.myvtex.com/eletronicos/d) and see it is working

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/43164235-09a03d74-8f67-11e8-92d4-b3521ea9c23c.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
