### PR TITLE
Provide Google Tag Manager native support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.4.0] - 2018-07-25
+
 ### Added
 -  Provide gtm support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+-  Provide gtm support
+
 ## [1.3.2] - 2018-07-25
 ### Changed
 - Delete all unnecessary path manipulation to not need pages information.

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,9 @@
   "vendor": "vtex",
   "name": "store",
   "version": "1.3.2",
+  "title": "VTEX Store",
+  "description":
+    "The VTEX basic store.",
   "builders": {
     "pages": "0.x",
     "react": "2.x"
@@ -15,5 +18,19 @@
   },
   "dependencies": {
     "vtex.store-graphql": "2.x"
+  },
+  "settingsSchema": {
+    "title": "VTEX Store",
+    "type": "object",
+    "properties": {
+      "gtmId": {
+        "title": "Google Tag Manager",
+        "type": "string",
+        "description": "Enter the ID (GTM-XXXX) from your Google Tag Manager container if you want to automatically use it"
+      }
+    }
+  },
+  "billingOptions": {
+    "free": true
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,9 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "title": "VTEX Store",
-  "description":
-    "The VTEX basic store.",
+  "description": "The VTEX basic store.",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -1,7 +1,11 @@
 import React, { Component } from 'react'
+import { Helmet } from 'render'
 import PropTypes from 'prop-types'
 
+import { gtmScript, gtmFrame} from './scripts/gtm'
 import { DataLayerProvider } from './components/withDataLayer'
+
+const APP_LOCATOR = 'vtex.store'
 
 class StoreContextProvider extends Component {
   static propTypes = {
@@ -13,8 +17,14 @@ class StoreContextProvider extends Component {
   }
 
   render() {
+    const settings = this.context.getSettings(APP_LOCATOR) || {}
     window.dataLayer = window.dataLayer || []
-
+    const {gtmId} = settings
+    const scripts = gtmId ? [{
+      'type': 'application/javascript',
+      'innerHTML': gtmScript(gtmId),
+    }] : []
+    const noscripts = gtmId ? [{id: "gtm_frame", innerHTML: gtmFrame(gtmId)}] : []
     return (
       <DataLayerProvider
         value={{
@@ -22,10 +32,15 @@ class StoreContextProvider extends Component {
           set: this.pushToDataLayer,
         }}
       >
-        <div className="vtex-store__template">{this.props.children}</div>
+      <Helmet script={scripts} noscript={noscripts} />
+      <div className="vtex-store__template">{this.props.children}</div>
       </DataLayerProvider>
     )
   }
+}
+
+StoreContextProvider.contextTypes = {
+  getSettings: PropTypes.func,
 }
 
 export default StoreContextProvider

--- a/react/scripts/gtm.js
+++ b/react/scripts/gtm.js
@@ -1,0 +1,7 @@
+export const gtmScript = (gtmId) => `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${gtmId}')`
+
+export const gtmFrame = (gtmId) => `<iframe src="https://www.googletagmanager.com/ns.html?id=${gtmId}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enable google tag manger use in all store pages.

#### How should this be manually tested?

1. Link `vtex.store` and configure some gtm identification accessing the admin path `admin/apps/vtex.store@1.3.1/setup`

2. Navigate in the store and check if `google tagmanager` script was injected on page. 

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
