### PR TITLE
Fix search result filters not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.4.6] - 2018-07-31
 ### Fixed
 - Search result filters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Search result filters.
 
 ## [1.4.5] - 2018-07-30
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -51,7 +51,7 @@ class ProductSearchContextProvider extends Component {
             <DataLayerApolloWrapper
               getData={this.getData}
               loading={
-                contextProps.state.loading || contextProps.searchQuery.loading
+                contextProps.loading || contextProps.searchQuery.loading
               }
             >
               {React.cloneElement(this.props.children, contextProps)}

--- a/react/components/SearchQueryContainer.js
+++ b/react/components/SearchQueryContainer.js
@@ -12,7 +12,9 @@ const DEFAULT_MAX_ITEMS_PER_PAGE = 1
 
 class SearchQueryContainer extends Component {
   state = {
-    maxItemsPerPage: DEFAULT_MAX_ITEMS_PER_PAGE,
+    variables: {
+      maxItemsPerPage: DEFAULT_MAX_ITEMS_PER_PAGE,
+    },
     /* Will be loading by default. The container will wait until the real data arrives */
     loading: true,
   }
@@ -30,11 +32,12 @@ class SearchQueryContainer extends Component {
         rest = '',
       },
     } = this.props
+    const { variables: { maxItemsPerPage } } = this.state
 
     const map = mapProps || createMap(params, rest)
     const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE
-    const from = (page - 1) * this.state.maxItemsPerPage
-    const to = from + this.state.maxItemsPerPage - 1
+    const from = (page - 1) * maxItemsPerPage
+    const to = from + maxItemsPerPage - 1
 
     const contextProps = {
       ...this.props,
@@ -49,25 +52,24 @@ class SearchQueryContainer extends Component {
       <Query
         query={searchQuery}
         variables={{
-          query: Object.values(params).join('/'),
+          query: Object.values(params).filter(s => s.length > 0).join('/'),
           map,
           rest,
           orderBy,
           from,
           to,
         }}
-        notifyOnNetworkStatusChange>
+        notifyOnNetworkStatusChange
+      >
         {searchQueryProps => (
           <SearchQueryContext.Provider
             value={{
-              state: {
-                ...this.state,
-                setContextVariables: variables =>
-                  this.setState({
-                    ...variables,
-                    /* When the real data arrives, isn't loading anymore */
-                    loading: false,
-                  }),
+              loading: this.state.loading,
+              setContextVariables: variables => {
+                this.setState({
+                  variables,
+                  loading: false,
+                })
               },
               ...contextProps,
               searchQuery: {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Refactor some of the handling of the query and fix the query not working due to an extra `/` at the end of the query.

#### What problem is this solving?
When you clicked on a filter on the search results page, the filter weren't being applied.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/eletronicos/s).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
