### PR TITLE
Fix Data Layer refresh + HomeContextProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Data Layer` to be recreated after each page change.
 
 ## [1.7.1] - 2018-08-02
 ### Fixed

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -5,7 +5,8 @@
       "context": "StoreContextProvider"
     },
     "store/home": {
-      "path": "/"
+      "path": "/",
+      "context": "HomeContextProvider"
     },
     "store/account": {
       "path": "/account",

--- a/react/HomeContextProvider.js
+++ b/react/HomeContextProvider.js
@@ -17,7 +17,7 @@ export default class HomeContextProvider extends Component {
 
   render() {
     return (
-      <DataLayerApolloWrapper getData={this.getData}>
+      <DataLayerApolloWrapper loading={false} getData={this.getData}>
         {this.props.children}
       </DataLayerApolloWrapper>
     )

--- a/react/HomeContextProvider.js
+++ b/react/HomeContextProvider.js
@@ -8,14 +8,12 @@ export default class HomeContextProvider extends Component {
     children: PropTypes.element,
   }
 
-  getData = () => {  
-    return [{
-      accountName: global.__RUNTIME__.account,
-      pageTitle: document.title,
-      pageUrl: location.href,
-      pageCategory: 'Home'
-    }]
-  }
+  getData = () => ({
+    accountName: global.__RUNTIME__.account,
+    pageTitle: document.title,
+    pageUrl: location.href,
+    pageCategory: 'Home'
+  })
 
   render() {
     return (

--- a/react/HomeContextProvider.js
+++ b/react/HomeContextProvider.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+import DataLayerApolloWrapper from './components/DataLayerApolloWrapper'
+
+class HomeContextProvider extends Component {
+  static propTypes = {
+    children: PropTypes.element,
+  }
+
+  getData = () => {  
+    return [{
+      accountName: global.__RUNTIME__.account,
+      pageTitle: document.title,
+      pageUrl: location.href,
+      pageCategory: 'Home'
+    }]
+  }
+
+  render() {
+    return (
+      <DataLayerApolloWrapper
+        getData={this.getData}
+      >
+        {this.props.children}
+      </DataLayerApolloWrapper>
+    )
+  }
+}
+
+export default HomeContextProvider

--- a/react/HomeContextProvider.js
+++ b/react/HomeContextProvider.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import DataLayerApolloWrapper from './components/DataLayerApolloWrapper'
 
-class HomeContextProvider extends Component {
+export default class HomeContextProvider extends Component {
   static propTypes = {
     children: PropTypes.element,
   }
@@ -19,13 +19,9 @@ class HomeContextProvider extends Component {
 
   render() {
     return (
-      <DataLayerApolloWrapper
-        getData={this.getData}
-      >
+      <DataLayerApolloWrapper getData={this.getData}>
         {this.props.children}
       </DataLayerApolloWrapper>
     )
   }
 }
-
-export default HomeContextProvider

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -23,10 +23,7 @@ class StoreContextProvider extends Component {
    * Ensure that the Data Layer will be recreated
    * after each children change (navigation).
    */
-  initDataLayer = () => {
-    const { dataLayer } = window
-    dataLayer.splice(0, dataLayer.length)
-  }
+  initDataLayer = () => window.dataLayer.splice(0, window.dataLayer.length)
 
   render() {
     const { country, locale, currency } = global.__RUNTIME__.culture

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -9,6 +9,9 @@ import { gtmScript, gtmFrame } from './scripts/gtm'
 const APP_LOCATOR = 'vtex.store'
 const CONTENT_TYPE = 'text/html;charset=utf-8'
 const META_ROBOTS = 'index, follow'
+
+let dataLayerInitialState = null
+
 class StoreContextProvider extends Component {
   static propTypes = {
     children: PropTypes.element,
@@ -18,11 +21,21 @@ class StoreContextProvider extends Component {
     window.dataLayer.push(obj)
   }
 
+  /**
+   * Ensure that the Data Layer will be recreated
+   * after each children change (navigation).
+   */
+  initDataLayer = () => {
+    if (!dataLayerInitialState && window.dataLayer) {
+      dataLayerInitialState = [ ...window.dataLayer ]
+    }
+    return dataLayerInitialState ? [ ...dataLayerInitialState ] : []
+  }
+
   render() {
-    window.dataLayer = window.dataLayer || []
     const { country, locale, currency } = global.__RUNTIME__.culture
     const settings = this.context.getSettings(APP_LOCATOR) || {}
-    console.log(settings)
+
     const {
       gtmId,
       titleTag,
@@ -30,6 +43,11 @@ class StoreContextProvider extends Component {
       metaTagKeywords,
       storeName,
     } = settings
+
+    window.dataLayer = this.initDataLayer()
+    
+    const settings = this.context.getSettings(APP_LOCATOR) || {}
+    const { gtmId } = settings
     const scripts = gtmId ? [{
       'type': 'application/javascript',
       'innerHTML': gtmScript(gtmId),

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -22,20 +22,13 @@ class StoreContextProvider extends Component {
   /**
    * Ensure that the Data Layer will be recreated
    * after each children change (navigation).
-   * 
-   * Insert to the Data Layer some default information.
    */
-  initDataLayer = ({ titleTag }) => {
+  initDataLayer = () => {
     const { dataLayer } = window
     dataLayer.splice(0, dataLayer.length)
-    dataLayer.push({
-      pageTitle: titleTag,
-      pageUrl: location.href
-    })
   }
 
   render() {
-<<<<<<< HEAD
     const { country, locale, currency } = global.__RUNTIME__.culture
     const settings = this.context.getSettings(APP_LOCATOR) || {}
 
@@ -47,15 +40,8 @@ class StoreContextProvider extends Component {
       storeName,
     } = settings
 
-    window.dataLayer = this.initDataLayer()
+    window.dataLayer && this.initDataLayer()
     
-=======
->>>>>>> Add init data layer function
-    const settings = this.context.getSettings(APP_LOCATOR) || {}
-
-    window.dataLayer && this.initDataLayer(settings)
-    
-    const { gtmId } = settings
     const scripts = gtmId ? [{
       'type': 'application/javascript',
       'innerHTML': gtmScript(gtmId),

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -10,8 +10,6 @@ const APP_LOCATOR = 'vtex.store'
 const CONTENT_TYPE = 'text/html;charset=utf-8'
 const META_ROBOTS = 'index, follow'
 
-let dataLayerInitialState = null
-
 class StoreContextProvider extends Component {
   static propTypes = {
     children: PropTypes.element,
@@ -24,15 +22,20 @@ class StoreContextProvider extends Component {
   /**
    * Ensure that the Data Layer will be recreated
    * after each children change (navigation).
+   * 
+   * Insert to the Data Layer some default information.
    */
-  initDataLayer = () => {
-    if (!dataLayerInitialState && window.dataLayer) {
-      dataLayerInitialState = [ ...window.dataLayer ]
-    }
-    return dataLayerInitialState ? [ ...dataLayerInitialState ] : []
+  initDataLayer = ({ titleTag }) => {
+    const { dataLayer } = window
+    dataLayer.splice(0, dataLayer.length)
+    dataLayer.push({
+      pageTitle: titleTag,
+      pageUrl: location.href
+    })
   }
 
   render() {
+<<<<<<< HEAD
     const { country, locale, currency } = global.__RUNTIME__.culture
     const settings = this.context.getSettings(APP_LOCATOR) || {}
 
@@ -46,7 +49,12 @@ class StoreContextProvider extends Component {
 
     window.dataLayer = this.initDataLayer()
     
+=======
+>>>>>>> Add init data layer function
     const settings = this.context.getSettings(APP_LOCATOR) || {}
+
+    window.dataLayer && this.initDataLayer(settings)
+    
     const { gtmId } = settings
     const scripts = gtmId ? [{
       'type': 'application/javascript',


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix Data Layer to be recreated after each page change
- Create HomeContextProvider to push to the data layer when the user it's in the home page.

#### What problem is this solving?
The data layer is the same in the entire store, once the `StoreContextProvider` it's only created once. Each page pushes to it, causing an object different in many contexts.

#### How should this be manually tested?
Access: https://andre--storecomponents.myvtex.com
Open the browser console and type `datalayer`.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)