### PR TITLE
 Fix error when destructuring product properties 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error destructuring properties of product when before inserting on data layer.
 
 ## [1.5.0] - 2018-07-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.5.1] - 2018-08-01
 ### Fixed
 - Error destructuring properties of product when before inserting on data layer.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -28,10 +28,57 @@ class ProductContextProvider extends Component {
       data: { product },
     } = this.props
 
+    const detailedProduct = {
+      accountName: global.__RUNTIME__.account,
+      pageCategory: 'Product',
+      pageDepartment: this.stripCategory(last(product.categories)),
+      pageFacets: [],
+      pageTitle: document.title,
+      pageUrl: window.location.href,
+      // productBrandId: 2123,
+      productBrandName: product.brand,
+      productCategoryId: Number(product.categoryId),
+      productCategoryName: last(
+        this.stripCategory(head(product.categories)).split('/')
+      ),
+      productDepartmentId: Number(
+        this.stripCategory(last(product.categoriesIds))
+      ),
+      productDepartmentName: this.stripCategory(last(product.categories)),
+      productId: product.productId,
+      productName: product.productName,
+      // shelfProductIds: Array[('2003029', '2002572')],
+      skuStockOutFromProductDetail: [],
+      skuStockOutFromShelf: [],
+      // skuStocks: { 2003960: 108 },
+    }
+
     const skuId = this.props.query.skuId || head(product.items).itemId
-    const [sku] = product.items.filter(product => product.itemId === skuId)
-    const { ean, referenceId: [{ Value: refIdValue }] } = sku
-    const [{ commertialOffer, sellerId }] = sku.sellers
+
+    const [sku] = product.items.filter(product => product.itemId === skuId) || []
+
+    if (sku) {
+      const { ean, referenceId } = sku
+
+      detailedProduct.productEans = [ean]
+
+      if (referenceId && referenceId.length >= 0) {
+        const [{ Value: refIdValue }] = referenceId
+
+        detailedProduct.productReferenceId = refIdValue
+      }
+
+      if (sku.sellers && sku.sellers.length >= 0) {
+        const [{ commertialOffer, sellerId }] = sku.sellers
+
+        detailedProduct.productListPriceFrom = commertialOffer.ListPrice
+        detailedProduct.productListPriceTo = commertialOffer.ListPrice
+        detailedProduct.productPriceFrom = commertialOffer.Price
+        detailedProduct.productPriceTo = commertialOffer.Price
+        detailedProduct.sellerId = sellerId
+        detailedProduct.sellerIds = sellerId
+      }
+    }
 
     return [
       {
@@ -42,44 +89,15 @@ class ProductContextProvider extends Component {
                 id: product.productId,
                 name: product.productName,
                 brand: product.brand,
-                category: this.stripCategory(path(['categories', '0'], product)),
+                category: this.stripCategory(
+                  path(['categories', '0'], product)
+                ),
               },
             ],
           },
         },
       },
-      {
-        accountName: global.__RUNTIME__.account,
-        pageCategory: 'Product',
-        pageDepartment: this.stripCategory(last(product.categories)),
-        pageFacets: [],
-        pageTitle: document.title,
-        pageUrl: window.location.href,
-        // productBrandId: 2123,
-        productBrandName: product.brand,
-        productCategoryId: Number(product.categoryId),
-        productCategoryName: last(
-          this.stripCategory(head(product.categories)).split('/')
-        ),
-        productDepartmentId: Number(
-          this.stripCategory(last(product.categoriesIds))
-        ),
-        productDepartmentName: this.stripCategory(last(product.categories)),
-        productEans: [ean],
-        productId: product.productId,
-        productListPriceFrom: commertialOffer.ListPrice,
-        productListPriceTo: commertialOffer.ListPrice,
-        productName: product.productName,
-        productPriceFrom: commertialOffer.Price,
-        productPriceTo: commertialOffer.Price,
-        productReferenceId: refIdValue,
-        sellerId: sellerId,
-        sellerIds: sellerId,
-        // shelfProductIds: Array[('2003029', '2002572')],
-        skuStockOutFromProductDetail: [],
-        skuStockOutFromShelf: [],
-        // skuStocks: { 2003960: 108 },
-      },
+      detailedProduct,
     ]
   }
 

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -57,27 +57,25 @@ class ProductContextProvider extends Component {
 
     const [sku] = product.items.filter(product => product.itemId === skuId) || []
 
-    if (sku) {
-      const { ean, referenceId } = sku
+    const { ean, referenceId } = sku
 
-      pageInfo.productEans = [ean]
+    pageInfo.productEans = [ean]
 
-      if (referenceId && referenceId.length >= 0) {
-        const [{ Value: refIdValue }] = referenceId
+    if (referenceId && referenceId.length >= 0) {
+      const [{ Value: refIdValue }] = referenceId
 
-        pageInfo.productReferenceId = refIdValue
-      }
+      pageInfo.productReferenceId = refIdValue
+    }
 
-      if (sku.sellers && sku.sellers.length >= 0) {
-        const [{ commertialOffer, sellerId }] = sku.sellers
+    if (sku.sellers && sku.sellers.length >= 0) {
+      const [{ commertialOffer, sellerId }] = sku.sellers
 
-        pageInfo.productListPriceFrom = commertialOffer.ListPrice
-        pageInfo.productListPriceTo = commertialOffer.ListPrice
-        pageInfo.productPriceFrom = commertialOffer.Price
-        pageInfo.productPriceTo = commertialOffer.Price
-        pageInfo.sellerId = sellerId
-        pageInfo.sellerIds = sellerId
-      }
+      pageInfo.productListPriceFrom = commertialOffer.ListPrice
+      pageInfo.productListPriceTo = commertialOffer.ListPrice
+      pageInfo.productPriceFrom = commertialOffer.Price
+      pageInfo.productPriceTo = commertialOffer.Price
+      pageInfo.sellerId = sellerId
+      pageInfo.sellerIds = sellerId
     }
 
     return [

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -28,7 +28,7 @@ class ProductContextProvider extends Component {
       data: { product },
     } = this.props
 
-    const detailedProduct = {
+    const pageInfo = {
       accountName: global.__RUNTIME__.account,
       pageCategory: 'Product',
       pageDepartment: this.stripCategory(last(product.categories)),
@@ -60,23 +60,23 @@ class ProductContextProvider extends Component {
     if (sku) {
       const { ean, referenceId } = sku
 
-      detailedProduct.productEans = [ean]
+      pageInfo.productEans = [ean]
 
       if (referenceId && referenceId.length >= 0) {
         const [{ Value: refIdValue }] = referenceId
 
-        detailedProduct.productReferenceId = refIdValue
+        pageInfo.productReferenceId = refIdValue
       }
 
       if (sku.sellers && sku.sellers.length >= 0) {
         const [{ commertialOffer, sellerId }] = sku.sellers
 
-        detailedProduct.productListPriceFrom = commertialOffer.ListPrice
-        detailedProduct.productListPriceTo = commertialOffer.ListPrice
-        detailedProduct.productPriceFrom = commertialOffer.Price
-        detailedProduct.productPriceTo = commertialOffer.Price
-        detailedProduct.sellerId = sellerId
-        detailedProduct.sellerIds = sellerId
+        pageInfo.productListPriceFrom = commertialOffer.ListPrice
+        pageInfo.productListPriceTo = commertialOffer.ListPrice
+        pageInfo.productPriceFrom = commertialOffer.Price
+        pageInfo.productPriceTo = commertialOffer.Price
+        pageInfo.sellerId = sellerId
+        pageInfo.sellerIds = sellerId
       }
     }
 
@@ -97,7 +97,7 @@ class ProductContextProvider extends Component {
           },
         },
       },
-      detailedProduct,
+      pageInfo,
     ]
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add conditions before accessing properties on the product.

#### What problem is this solving?
Not all properties are available on the product object, so on a store that don't have a product with all fields filled it would break the page when it tried to add to the data layer.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
