### PR TITLE
Change breadcrumbs props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change the props passed to the Breadcrumbs
 
 ## [1.7.1] - 2018-08-02
 ### Fixed

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -119,7 +119,7 @@ class ProductContextProvider extends Component {
       product,
     }
 
-    const breadCrumbsProps = {
+    const breadcrumbsProps = {
       term: slug,
       categories: product ? product.categories : null,
     }
@@ -135,7 +135,7 @@ class ProductContextProvider extends Component {
             {React.cloneElement(this.props.children, {
               productQuery,
               slug,
-              ...breadCrumbsProps,
+              ...breadcrumbsProps,
             })}
           </DataLayerApolloWrapper>
         </Fragment>

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -119,6 +119,9 @@ class ProductContextProvider extends Component {
       product,
     }
 
+    /**
+     * The breadcrumbs components is being used in multiple pages, therefore we need to adapt the data to its needs insteadof
+     * making the component do the changes it self.**/
     const breadcrumbsProps = {
       term: slug,
       categories: product ? product.categories : null,

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -119,6 +119,11 @@ class ProductContextProvider extends Component {
       product,
     }
 
+    const breadCrumbsProps = {
+      term: slug,
+      categories: product ? product.categories : null,
+    }
+
     return (
       <div className="vtex-product-details-container">
         <Fragment>
@@ -130,6 +135,7 @@ class ProductContextProvider extends Component {
             {React.cloneElement(this.props.children, {
               productQuery,
               slug,
+              ...breadCrumbsProps,
             })}
           </DataLayerApolloWrapper>
         </Fragment>

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -18,11 +18,10 @@ class ProductSearchContextProvider extends Component {
   }
 
   getBreadcrumbsProps() {
-    const { params } = this.props
+    const {
+      params: { category, department, term },
+    } = this.props
 
-    let category = params.category || ''
-
-    let department = params.department || ''
     const categories = []
 
     if (department) {
@@ -37,7 +36,7 @@ class ProductSearchContextProvider extends Component {
     }
 
     const breadcrumbsProps = {
-      term: params.term,
+      term,
       categories,
     }
 

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -25,22 +25,18 @@ class ProductSearchContextProvider extends Component {
     const categories = []
 
     if (department) {
-      department = department.charAt(0).toUpperCase() + department.substr(1)
       categories.push(department)
     }
 
     if (category) {
-      category = `${department}/${category.charAt(0).toUpperCase() +
-        category.substr(1)}/`
+      category = `${department}/${category}/`
       categories.push(category)
     }
 
-    const breadcrumbsProps = {
+    return {
       term,
       categories,
     }
-
-    return breadcrumbsProps
   }
 
   getData = searchQuery => {

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -17,6 +17,33 @@ class ProductSearchContextProvider extends Component {
     loading: true,
   }
 
+  getBreadcrumbsProps() {
+    const { params } = this.props
+
+    let category = params.category || ''
+
+    let department = params.department || ''
+    const categories = []
+
+    if (department) {
+      department = department.charAt(0).toUpperCase() + department.substr(1)
+      categories.push(department)
+    }
+
+    if (category) {
+      category = `${department}/${category.charAt(0).toUpperCase() +
+        category.substr(1)}/`
+      categories.push(category)
+    }
+
+    const breadcrumbsProps = {
+      term: params.term,
+      categories,
+    }
+
+    return breadcrumbsProps
+  }
+
   getData = searchQuery => {
     if (!searchQuery) {
       return null
@@ -69,6 +96,8 @@ class ProductSearchContextProvider extends Component {
 
     const { params, map, rest, orderBy, from, to } = props
 
+    const breadcrumbsProps = this.getBreadcrumbsProps()
+
     return (
       <Query
         query={searchQuery}
@@ -101,6 +130,7 @@ class ProductSearchContextProvider extends Component {
                 ...searchQueryProps,
                 ...searchQueryProps.data.search,
               },
+              ...breadcrumbsProps,
             })}
           </DataLayerApolloWrapper>
         )}

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -18,7 +18,7 @@ class ProductSearchContextProvider extends Component {
   }
 
   getBreadcrumbsProps() {
-    const {
+    let {
       params: { category, department, term },
     } = this.props
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the props passed to the Breadcrumbs and add it to the SearchResult page.

#### What problem is this solving?
Now the breadcrumbs component can be used on the SearchResult page.

#### How should this be manually tested?
[workspace](https://felipeoficial--storecomponents.myvtex.com/eletronicos/computadores/c)

#### Linked to

[breadcrumbs](https://github.com/vtex-apps/breadcrumb/pull/9)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3926634/43644883-9fad0882-9706-11e8-844e-388efd73d8df.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
