### PR TITLE
Remove sufixes from routes that are not ambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Search paths(`/d, /c, /sc, /s`) doesn't have sufix anymore. 
 
 ## [1.7.4] - 2018-08-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.8.0] - 2018-08-06
 ### Removed
 - Unambiguous search paths (`/c, /sc, /s`) don't have suffix anymore. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Removed
-- Search paths(`/d, /c, /sc, /s`) doesn't have sufix anymore. 
+- Unambiguous search paths (`/c, /sc, /s`) don't have suffix anymore. 
 
 ## [1.7.4] - 2018-08-03
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -27,7 +27,7 @@
       "context": "ProductSearchContextProvider"
     },
     "store/department": {
-      "path": "/:department/d",
+      "path": "/:department",
       "context": "ProductSearchContextProvider"
     },
     "store/category": {

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -27,7 +27,7 @@
       "context": "ProductSearchContextProvider"
     },
     "store/department": {
-      "path": "/:department",
+      "path": "/:department/d",
       "context": "ProductSearchContextProvider"
     },
     "store/category": {

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -31,11 +31,11 @@
       "context": "ProductSearchContextProvider"
     },
     "store/category": {
-      "path": "/:department/:category/c",
+      "path": "/:department/:category",
       "context": "ProductSearchContextProvider"
     },
     "store/subcategory": {
-      "path": "/:department/:category/:subcategory/sc",
+      "path": "/:department/:category/:subcategory",
       "context": "ProductSearchContextProvider"
     },
     "store/product": {
@@ -43,7 +43,7 @@
       "context": "ProductContextProvider"
     },
     "store/search": {
-      "path": "/:term/s",
+      "path": "/:term",
       "context": "ProductSearchContextProvider"
     }
   }


### PR DESCRIPTION
Search paths(`/d, /c, /sc, /s`) doesn't have sufix anymore.