### PR TITLE
Add flag for which page the component inside the search context is

### DIFF
--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Query } from 'react-apollo'
 import { Helmet } from 'render'
+
 import searchQuery from './queries/searchQuery.gql'
 import DataLayerApolloWrapper from './components/DataLayerApolloWrapper'
 import { processSearchContextProps } from './helpers/searchHelpers'
@@ -9,6 +11,15 @@ const DEFAULT_PAGE = 1
 const DEFAULT_MAX_ITEMS_PER_PAGE = 1
 
 class ProductSearchContextProvider extends Component {
+  static propTypes = {
+    params: PropTypes.shape({
+      category: PropTypes.string,
+      department: PropTypes.string,
+      term: PropTypes.string,
+    }),
+    children: PropTypes.node.isRequired,
+  }
+
   state = {
     variables: {
       maxItemsPerPage: DEFAULT_MAX_ITEMS_PER_PAGE,
@@ -17,8 +28,8 @@ class ProductSearchContextProvider extends Component {
     loading: true,
   }
 
-  getBreadcrumbsProps() {
-    let {
+  get breadcrumbsProps() {
+    const {
       params: { category, department, term },
     } = this.props
 
@@ -29,8 +40,7 @@ class ProductSearchContextProvider extends Component {
     }
 
     if (category) {
-      category = `${department}/${category}/`
-      categories.push(category)
+      categories.push(`${department}/${category}/`)
     }
 
     return {
@@ -38,9 +48,9 @@ class ProductSearchContextProvider extends Component {
       categories,
     }
   }
-  
+
   pageCategory = products => {
-    if (products.length == 0) {
+    if (products.length === 0) {
       return 'EmptySearch'
     }
     const { category, term } = this.props.params
@@ -48,7 +58,7 @@ class ProductSearchContextProvider extends Component {
   }
 
   getPageEventName = products => {
-    if (products.length == 0) {
+    if (products.length === 0) {
       return 'otherView'
     }
     const pageCategory = this.pageCategory(products)
@@ -72,9 +82,9 @@ class ProductSearchContextProvider extends Component {
             category: searchQuery.facets.CategoriesTrees[index]
               ? searchQuery.facets.CategoriesTrees[index].Name
               : category,
-            position: index + 1 + '',
+            position: `${index + 1}`,
             price: product
-              ? product.items[0].sellers[0].commertialOffer.Price + ''
+              ? `${product.items[0].sellers[0].commertialOffer.Price}`
               : '',
           })),
         },
@@ -88,8 +98,8 @@ class ProductSearchContextProvider extends Component {
         pageUrl: window.location.href,
       },
       {
-        event: this.getPageEventName(products)
-      }
+        event: this.getPageEventName(products),
+      },
     ]
   }
 
@@ -107,8 +117,6 @@ class ProductSearchContextProvider extends Component {
       DEFAULT_PAGE
     )
     const { params, map, rest, orderBy, from, to } = props
-
-    const breadcrumbsProps = this.getBreadcrumbsProps()
 
     return (
       <Query
@@ -129,11 +137,7 @@ class ProductSearchContextProvider extends Component {
           const data = searchQueryProps.data || {}
           return (
             <DataLayerApolloWrapper
-              getData={() =>
-                this.getData({
-                  ...data.search,
-                })
-              }
+              getData={() => this.getData(data.search)}
               loading={this.state.loading || searchQueryProps.loading}
             >
               {!searchQueryProps.loading && data.search &&
@@ -145,18 +149,18 @@ class ProductSearchContextProvider extends Component {
                 </Helmet>
               }
               {React.cloneElement(this.props.children, {
+                ...props,
                 loading: this.state.loading,
                 setContextVariables: this.handleContextVariables,
-                ...props,
                 searchQuery: {
                   ...searchQueryProps,
                   ...data.search,
                 },
-                ...breadcrumbsProps
+                ...this.breadcrumbsProps,
               })}
             </DataLayerApolloWrapper>
-          )}
-        }
+          )
+        }}
       </Query>
     )
   }

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Query } from 'react-apollo'
-import { Helmet } from 'render'
+import { Helmet, withRuntimeContext } from 'render'
 
 import searchQuery from './queries/searchQuery.gql'
 import DataLayerApolloWrapper from './components/DataLayerApolloWrapper'
@@ -18,6 +18,9 @@ class ProductSearchContextProvider extends Component {
       term: PropTypes.string,
     }),
     children: PropTypes.node.isRequired,
+    runtime: PropTypes.shape({
+      page: PropTypes.string.isRequired,
+    }),
   }
 
   state = {
@@ -47,6 +50,12 @@ class ProductSearchContextProvider extends Component {
       term,
       categories,
     }
+  }
+
+  isPage = path => {
+    const { runtime: { page } } = this.props
+
+    return `store/${path}` === page
   }
 
   pageCategory = products => {
@@ -157,6 +166,11 @@ class ProductSearchContextProvider extends Component {
                   ...data.search,
                 },
                 ...this.breadcrumbsProps,
+                departmentPage: this.isPage('department'),
+                categoryPage: this.isPage('category'),
+                subcategoryPage: this.isPage('subcategory'),
+                bandPage: this.isPage('brand'),
+                searchPage: this.isPage('search'),
               })}
             </DataLayerApolloWrapper>
           )
@@ -166,4 +180,4 @@ class ProductSearchContextProvider extends Component {
   }
 }
 
-export default ProductSearchContextProvider
+export default withRuntimeContext(ProductSearchContextProvider)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a flag indicating which page is the component inserted on.

#### What problem is this solving?
Before, you needed to check for the attributes in the `params` object to check for this.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
