### PR TITLE
Update search query to include Id and Slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update search query to include the `Id` and `Slug` fields in the corresponding types.
 
 ## [1.12.2] - 2018-08-23
 ### Changed

--- a/react/queries/searchQuery.gql
+++ b/react/queries/searchQuery.gql
@@ -22,14 +22,17 @@ query search($query: String, $map: String, $rest: String, $orderBy: String, $fro
         }
       }
       CategoriesTrees {
+        Id
         Quantity
         Name
         Link
         Children {
+          Id
           Quantity
           Name
           Link
           Children {
+            Id
             Quantity
             Name
             Link
@@ -40,8 +43,9 @@ query search($query: String, $map: String, $rest: String, $orderBy: String, $fro
         Quantity
         Name
         Link
+        Slug
       }
-    } 
+    }
     products {
       productId
       productName


### PR DESCRIPTION
---

Depends on vtex-apps/store-graphql#104

---

#### What is the purpose of this pull request?
Update the search query so it includes the new fields `Id` and `Slug` on the appropriate types.

#### What problem is this solving?
The query was outdated.

#### Types of changes

* [x] New feature (a non-breaking change which adds functionality)