### PR TITLE
Add SKU data to the benefit in the `productQuery` and fix products is undefined error on SearchContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.13.1] - 2018-08-31
 ### Fixed
 - *HotFix* undefined verification in the `ProductSearchContextProvider`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `benefitSKUIds` property to the benefit data of the `productQuery`.
 
 ## [1.13.0] - 2018-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- undefined verification in the `ProductSearchContextProvider`.
+
 ### Added
 - `benefitSKUIds` property to the benefit data of the `productQuery`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- undefined verification in the `ProductSearchContextProvider`.
+- *HotFix* undefined verification in the `ProductSearchContextProvider`.
 
 ### Added
 - `benefitSKUIds` property to the benefit data of the `productQuery`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -10,9 +10,14 @@ import searchQuery from './queries/searchQuery.gql'
 const DEFAULT_PAGE = 1
 const DEFAULT_MAX_ITEMS_PER_PAGE = 1
 
-const canonicalPathFromParams = ({brand, department, category, subcategory}) =>
+const canonicalPathFromParams = ({
+  brand,
+  department,
+  category,
+  subcategory,
+}) =>
   ['', brand || department, category, subcategory].reduce(
-    (acc, curr) => curr ? `${acc}/${curr}` : acc
+    (acc, curr) => (curr ? `${acc}/${curr}` : acc)
   )
 
 class ProductSearchContextProvider extends Component {
@@ -45,7 +50,7 @@ class ProductSearchContextProvider extends Component {
   }
 
   getPageEventName = products => {
-    if (products.length === 0) {
+    if (!products || products.length === 0) {
       return 'otherView'
     }
     const pageCategory = this.pageCategory(products)
@@ -62,19 +67,21 @@ class ProductSearchContextProvider extends Component {
     return [
       {
         ecommerce: {
-          impressions: Array.isArray(products) && products.map((product, index) => ({
-            id: product.productId,
-            name: product.productName,
-            list: 'Search Results',
-            brand: product.brand,
-            category: searchQuery.facets.CategoriesTrees[index]
-              ? searchQuery.facets.CategoriesTrees[index].Name
-              : category,
-            position: `${index + 1}`,
-            price: product
-              ? `${product.items[0].sellers[0].commertialOffer.Price}`
-              : '',
-          })),
+          impressions:
+            Array.isArray(products) &&
+            products.map((product, index) => ({
+              id: product.productId,
+              name: product.productName,
+              list: 'Search Results',
+              brand: product.brand,
+              category: searchQuery.facets.CategoriesTrees[index]
+                ? searchQuery.facets.CategoriesTrees[index].Name
+                : category,
+              position: `${index + 1}`,
+              price: product
+                ? `${product.items[0].sellers[0].commertialOffer.Price}`
+                : '',
+            })),
         },
       },
       {
@@ -127,41 +134,44 @@ class ProductSearchContextProvider extends Component {
           from,
           to,
         }}
-        notifyOnNetworkStatusChange
-      >
+        notifyOnNetworkStatusChange>
         {searchQueryProps => {
-          const {data, loading} = searchQueryProps
-          const {search} = data || {}
-          const {titleTag, metaTagDescription} = search || {}
+          const { data, loading } = searchQueryProps
+          const { search } = data || {}
+          const { titleTag, metaTagDescription } = search || {}
           return (
-          <DataLayerApolloWrapper
-            getData={() =>
-              this.getData({
-                ...search,
-              })
-            }
-            loading={this.state.loading || loading}
-          >
-            <Helmet>
-              {params
-                && <link rel='canonical' href={canonicalPathFromParams(params)}></link>}
-              {titleTag
-                && <title>{titleTag}</title>}
-              {metaTagDescription
-                && <meta name="description" content={metaTagDescription} />}
-            </Helmet>
-            {React.cloneElement(this.props.children, {
-              loading: this.state.loading,
-              setContextVariables: this.handleContextVariables,
-              ...props,
-              searchQuery: {
-                ...searchQueryProps,
-                ...search,
-              },
-              searchContext: page,
-            })}
-          </DataLayerApolloWrapper>
-        )}}
+            <DataLayerApolloWrapper
+              getData={() =>
+                this.getData({
+                  ...search,
+                })
+              }
+              loading={this.state.loading || loading}>
+              <Helmet>
+                {params && (
+                  <link
+                    rel="canonical"
+                    href={canonicalPathFromParams(params)}
+                  />
+                )}
+                {titleTag && <title>{titleTag}</title>}
+                {metaTagDescription && (
+                  <meta name="description" content={metaTagDescription} />
+                )}
+              </Helmet>
+              {React.cloneElement(this.props.children, {
+                loading: this.state.loading,
+                setContextVariables: this.handleContextVariables,
+                ...props,
+                searchQuery: {
+                  ...searchQueryProps,
+                  ...search,
+                },
+                searchContext: page,
+              })}
+            </DataLayerApolloWrapper>
+          )
+        }}
       </Query>
     )
   }

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -1,11 +1,11 @@
-import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import React, { Component } from 'react'
 import { Query } from 'react-apollo'
 import { Helmet, withRuntimeContext } from 'render'
 
-import searchQuery from './queries/searchQuery.gql'
 import DataLayerApolloWrapper from './components/DataLayerApolloWrapper'
 import { processSearchContextProps } from './helpers/searchHelpers'
+import searchQuery from './queries/searchQuery.gql'
 
 const DEFAULT_PAGE = 1
 const DEFAULT_MAX_ITEMS_PER_PAGE = 1
@@ -37,7 +37,7 @@ class ProductSearchContextProvider extends Component {
   }
 
   pageCategory = products => {
-    if (products.length === 0) {
+    if (!products || products.length === 0) {
       return 'EmptySearch'
     }
     const { category, term } = this.props.params

--- a/react/queries/productQuery.gql
+++ b/react/queries/productQuery.gql
@@ -328,6 +328,7 @@ query Product($slug: String) {
         }
         discount
         minQuantity
+        benefitSKUIds
       }
       teaserType
     }


### PR DESCRIPTION
Referenced Pull Requests:
- https://github.com/vtex-apps/store-graphql/pull/115

#### What is the purpose of this pull request?
Add SKU data to the benefit in the `productQuery` and fix products is `undefined` error on ProductsSearchContext.

#### What problem is this solving?
Improvement the benefits data in order to bring the information about what SKU items composes each benefit. Fix application error.

#### Screenshots or example usage
<a href="https://productkit--storecomponents.myvtex.com/">Click here to access the workspace</a>

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
