### PR TITLE
Update data layer hoc to hoist non react statics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Hoist non react statics on data layer hoc.
 
 ## [1.13.1] - 2018-08-31
 ### Fixed

--- a/react/components/withDataLayer.js
+++ b/react/components/withDataLayer.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import hoistNonReactStatics from 'hoist-non-react-statics'
 
 const { Consumer, Provider } = React.createContext({
   dataLayer: [],
@@ -9,7 +10,7 @@ const { Consumer, Provider } = React.createContext({
 export { Provider as DataLayerProvider }
 
 export default function withDataLayer(WrappedComponent) {
-  return class DataLayer extends Component {
+  class DataLayer extends Component {
     static displayName =
       `DataLayer(${WrappedComponent.displayName || WrappedComponent.name})`
 
@@ -23,6 +24,8 @@ export default function withDataLayer(WrappedComponent) {
       )
     }
   }
+
+  return hoistNonReactStatics(DataLayer, WrappedComponent)
 }
 
 export const dataLayerProps = {

--- a/react/package.json
+++ b/react/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "@vtex/styleguide": "^3.0.2",
+    "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.5.10",
     "react-slick": "^0.16.0"
   },

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -16,10 +16,6 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@types/async@2.0.47":
-  version "2.0.47"
-  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.47.tgz#f49ba1dd1f189486beb6e1d070a850f6ab4bd521"
-
 "@types/async@2.0.49":
   version "2.0.49"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"
@@ -36,26 +32,9 @@
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.3.tgz#91b728599544efbb7386d8b6633693a3c2e7ade5"
 
-"@vtex/buy-button@0.1.21":
-  version "0.1.21"
-  resolved "https://registry.yarnpkg.com/@vtex/buy-button/-/buy-button-0.1.21.tgz#37ed9a8be2d7286429d31f407fa7f7e487fdaf53"
-  dependencies:
-    "@vtex/styleguide" "2.0.0-rc.34"
-    apollo-client "~2.2.3"
-    graphql "~0.13.2"
-    graphql-tag "~2.8.0"
-    react-apollo "~2.1.3"
-
-"@vtex/styleguide@2.0.0-rc.34":
-  version "2.0.0-rc.34"
-  resolved "https://registry.yarnpkg.com/@vtex/styleguide/-/styleguide-2.0.0-rc.34.tgz#def960cf4c9de0a2fbe5a2c8cad122c7e3b5f7d8"
-  dependencies:
-    react-responsive-modal "^2.0.1"
-    vtex-tachyons "^2.3.0"
-
-"@vtex/styleguide@2.0.0-rc.40":
-  version "2.0.0-rc.40"
-  resolved "https://registry.yarnpkg.com/@vtex/styleguide/-/styleguide-2.0.0-rc.40.tgz#962221e5a6bf5fb53650ebe955f48e243b97b5e3"
+"@vtex/styleguide@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@vtex/styleguide/-/styleguide-3.0.2.tgz#c733da13c46d750ea8987de22d349b03eea071f0"
   dependencies:
     react-responsive-modal "^2.0.1"
     vtex-tachyons "^2.3.0"
@@ -136,7 +115,7 @@ apollo-cache-inmemory@^1.1.7:
     apollo-utilities "^1.0.12"
     graphql-anywhere "^4.1.10"
 
-apollo-cache@^1.1.7, apollo-cache@^1.1.8:
+apollo-cache@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.8.tgz#b078d33dec876d52b5a81a325d3c254d4e362d3c"
   dependencies:
@@ -166,20 +145,6 @@ apollo-client@^2.2.2:
   optionalDependencies:
     "@types/async" "2.0.49"
 
-apollo-client@~2.2.3:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.2.8.tgz#b604d31ab2d2dd00db3105d8793b93ee02ce567e"
-  dependencies:
-    "@types/zen-observable" "^0.5.3"
-    apollo-cache "^1.1.7"
-    apollo-link "^1.0.0"
-    apollo-link-dedup "^1.0.0"
-    apollo-utilities "^1.0.11"
-    symbol-observable "^1.0.2"
-    zen-observable "^0.7.0"
-  optionalDependencies:
-    "@types/async" "2.0.47"
-
 apollo-link-dedup@^1.0.0:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.9.tgz#3c4e4af88ef027cbddfdb857c043fd0574051dad"
@@ -207,7 +172,7 @@ apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.2:
     apollo-utilities "^1.0.0"
     zen-observable-ts "^0.8.9"
 
-apollo-utilities@^1.0.0, apollo-utilities@^1.0.11, apollo-utilities@^1.0.12:
+apollo-utilities@^1.0.0, apollo-utilities@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.12.tgz#9e2b2a34cf89f3bf0d73a664effd8c1bb5d1b7f7"
 
@@ -1866,11 +1831,7 @@ graphql-tag@^2.4.2, graphql-tag@^2.7.3:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.9.2.tgz#2f60a5a981375f430bf1e6e95992427dc18af686"
 
-graphql-tag@~2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.8.0.tgz#52cdea07a842154ec11a2e840c11b977f9b835ce"
-
-graphql@^0.13.0, graphql@~0.13.2:
+graphql@^0.13.0:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:
@@ -1972,6 +1933,12 @@ hoek@4.x.x:
 hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+
+hoist-non-react-statics@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz#fba3e7df0210eb9447757ca1a7cb607162f0a364"
+  dependencies:
+    react-is "^16.3.2"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3535,7 +3502,7 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-apollo@^2.0.4, react-apollo@~2.1.3:
+react-apollo@^2.0.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.1.4.tgz#a51059ac56f1a7997cad636a5d36398b9c93ff12"
   dependencies:
@@ -4482,10 +4449,6 @@ zen-observable-ts@^0.8.9:
   resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.9.tgz#d3c97af08c0afdca37ebcadf7cc3ee96bda9bab1"
   dependencies:
     zen-observable "^0.8.0"
-
-zen-observable@^0.7.0:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.7.1.tgz#f84075c0ee085594d3566e1d6454207f126411b3"
 
 zen-observable@^0.8.0:
   version "0.8.8"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add proxy to hoist non react statics inside the data layer high order component.

#### What problem is this solving?
To adhere to the community stablished pattern of hoisting the non-react statics from the wrapped component, which solves some problems related to schema (as it is a non-react static) that required some extra effort to pass to the HOCd component.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
