### PR TITLE
Fix undefined categories prop in ProductContextProvider

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,8 @@
   "env": {
     "browser": true,
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "jest": true
   },
   "globals": {
     "__DEV__": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix undefined categories prop in `ProductContextProvider`. 
+
+### Removed
+- Now, `my-orders-app` is embedded in `my-account`, this make the route `account/orders` useless.
 
 ## [1.14.0] - 2018-09-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.14.1] - 2018-09-13
 ### Fixed
 - Fix undefined categories prop in `ProductContextProvider`. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix undefined categories prop in `ProductContextProvider`. 
 
 ### Removed
-- Now, `my-orders-app` is embedded in `my-account`, this make the route `account/orders` useless.
+- Now, `my-orders-app` is embedded in `my-account`, this makes the route `account/orders` useless.
 
 ## [1.14.0] - 2018-09-10
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -12,10 +12,6 @@
       "path": "/account",
       "login": true
     },
-    "store/account/orders": {
-      "path": "/account/orders",
-      "login": true
-    },
     "store/compare": {
       "path": "/compare"
     },

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -27,6 +27,7 @@ class ProductContextProvider extends Component {
   getData = () => {
     const {
       data: { product },
+      query,
     } = this.props
     const {
       titleTag,
@@ -69,7 +70,7 @@ class ProductContextProvider extends Component {
       skuStockOutFromShelf: [],
     }
 
-    const skuId = this.props.query.skuId || (items && head(items).itemId)
+    const skuId = query.skuId || (items && head(items).itemId)
 
     const [sku] =
       (items && items.filter(product => product.itemId === skuId)) || []

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -46,8 +46,8 @@ class ProductContextProvider extends Component {
     const pageInfo = {
       accountName: global.__RUNTIME__.account,
       pageCategory: 'Product',
-      pageDepartment: product
-        ? this.stripCategory(last(product.categories))
+      pageDepartment: categories
+        ? this.stripCategory(last(categories))
         : '',
       pageFacets: [],
       pageTitle: titleTag,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix undefined categories prop in ProductContextProvider
Also, `my-orders-app` is embedded in `my-account`, this makes the route `account/orders` useless.
#### Screenshots or example usage
https://store--storecomponents.myvtex.com/

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
