### PR TITLE
Add ProductSearchContextProvider schema to eliminate the SearchResult…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.17.0] - 2018-09-20
 ### Added
 - `ProductSearchContextProvider` schema to eliminate the `SearchResult` dependency.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ProductSearchContextProvider` schema to eliminate the `SearchResult` dependency.
 
 ## [1.16.0] - 2018-09-18
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -3,12 +3,12 @@ import React, { Component } from 'react'
 import { Query } from 'react-apollo'
 import { Helmet, withRuntimeContext } from 'render'
 
-import { SORT_OPTIONS, createMap, canonicalPathFromParams } from './utils/search'
 import DataLayerApolloWrapper from './components/DataLayerApolloWrapper'
 import searchQuery from './queries/searchQuery.gql'
+import { canonicalPathFromParams, createMap, SORT_OPTIONS } from './utils/search'
 
 const DEFAULT_PAGE = 1
-const DEFAULT_MAX_ITEMS_PER_PAGE = 1
+const DEFAULT_MAX_ITEMS_PER_PAGE = 10
 
 class ProductSearchContextProvider extends Component {
   static propTypes = {
@@ -35,12 +35,19 @@ class ProductSearchContextProvider extends Component {
     children: PropTypes.node.isRequired,
   }
 
-  state = {
-    variables: {
-      maxItemsPerPage: DEFAULT_MAX_ITEMS_PER_PAGE,
+  static defaultProps = {
+    maxItemsPerPage: DEFAULT_MAX_ITEMS_PER_PAGE,
+  }
+
+  static schema = {
+    title: 'editor.product-search.title',
+    type: 'object',
+    properties: {
+      maxItemsPerPage: {
+        title: 'editor.product-search.maxItemsPerPage',
+        type: 'number',
+      },
     },
-    /* Will be loading by default. The container will wait until the real data arrives */
-    loading: true,
   }
 
   pageCategory = products => {
@@ -100,17 +107,11 @@ class ProductSearchContextProvider extends Component {
     ]
   }
 
-  handleContextVariables = variables => {
-    this.setState({
-      variables,
-      loading: false,
-    })
-  }
-
   render() {
     const {
       nextTreePath,
       params,
+      maxItemsPerPage,
       query: {
         order: orderBy = SORT_OPTIONS[0].value,
         page: pageProps,
@@ -120,8 +121,6 @@ class ProductSearchContextProvider extends Component {
       },
       runtime: { page: runtimePage },
     } = this.props
-
-    const { variables: { maxItemsPerPage } } = this.state
 
     const map = mapProps || createMap(params, rest)
     const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE
@@ -155,7 +154,7 @@ class ProductSearchContextProvider extends Component {
                   ...search,
                 })
               }
-              loading={this.state.loading || loading}
+              loading={loading}
             >
               <Helmet>
                 {params && (
@@ -175,8 +174,6 @@ class ProductSearchContextProvider extends Component {
                   ...searchQueryProps,
                   ...search,
                 },
-                loading: this.state.loading,
-                setContextVariables: this.handleContextVariables,
                 searchContext: runtimePage,
                 pagesPath: nextTreePath,
                 map,

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -6,5 +6,7 @@
   "dreamstore.cart": "Cart",
   "dreamstore.buy": "Buy",
   "dreamstore.poweredBy": "POWERED BY",
-  "dreamstore.buy-success": "Your product was add to the cart!"
+  "dreamstore.buy-success": "Your product was add to the cart!",
+  "editor.product-search.title": "Product search context",
+  "editor.product-search.maxItemsPerPage": "Maximum number of items per page"
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -6,5 +6,7 @@
   "dreamstore.cart": "Carrito",
   "dreamstore.buy": "Comprar",
   "dreamstore.poweredBy": "IMPULSADO POR VTEX",
-  "dreamstore.buy-success": "Su producto se ha agregado a la cesta!"
+  "dreamstore.buy-success": "Su producto se ha agregado a la cesta!",
+  "editor.product-search.title": "Contexto de búsqueda de productos",
+  "editor.product-search.maxItemsPerPage": "Número máximo de elementos por página"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -6,5 +6,7 @@
   "dreamstore.cart": "Carrinho",
   "dreamstore.buy": "Comprar",
   "dreamstore.poweredBy": "FORNECIDO POR VTEX",
-  "dreamstore.buy-success": "Seu produto foi adicionado ao carrinho!"
+  "dreamstore.buy-success": "Seu produto foi adicionado ao carrinho!",
+  "editor.product-search.title": "Contexto de busca de produtos",
+  "editor.product-search.maxItemsPerPage": "Número máximo de elementos por página"
 }


### PR DESCRIPTION
#### Depends on: 
- [search-result](https://github.com/vtex-apps/search-result/pull/43)

#### What is the purpose of this pull request?

Add ProductSearchContextProvider schema to eliminate the SearchResult dependency

#### What problem is this solving?

SearchResult needed to be rendered to change and set the product search query correct variables.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/admin/cms/storefront)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/45637248-5df94e80-ba80-11e8-9f51-a3e3d4867d18.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
