### PR TITLE
Fix query on brand page with wrong arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.18.1] - 2018-09-27
 ### Fixed
 - Fix query on brand page with wrong arguments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix query on brand page with wrong arguments.
 
 ## [1.18.0] - 2018-09-25
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -7,7 +7,7 @@ import DataLayerApolloWrapper from './components/DataLayerApolloWrapper'
 import searchQuery from './queries/searchQuery.gql'
 import {
   canonicalPathFromParams,
-  createMap,
+  createInitialMap,
   SORT_OPTIONS,
 } from './utils/search'
 
@@ -25,6 +25,8 @@ class ProductSearchContextProvider extends Component {
     /** Render runtime context */
     runtime: PropTypes.shape({
       page: PropTypes.string.isRequired,
+      prefetchPage: PropTypes.func.isRequired,
+      account: PropTypes.any,
     }),
     /** Query params */
     query: PropTypes.shape({
@@ -37,6 +39,8 @@ class ProductSearchContextProvider extends Component {
     nextTreePath: PropTypes.string,
     /** Component to be rendered */
     children: PropTypes.node.isRequired,
+    /** Max items to show per result page */
+    maxItemsPerPage: PropTypes.number.isRequired,
   }
 
   componentDidMount() {
@@ -125,16 +129,16 @@ class ProductSearchContextProvider extends Component {
       maxItemsPerPage,
       query: {
         order: orderBy = SORT_OPTIONS[0].value,
-        page: pageProps,
-        map: mapProps,
+        page: pageQuery,
+        map: mapQuery,
         rest = '',
         priceRange,
       },
       runtime: { page: runtimePage },
     } = this.props
 
-    const map = mapProps || createMap(params, rest)
-    const page = pageProps ? parseInt(pageProps) : DEFAULT_PAGE
+    const map = mapQuery || createInitialMap(params)
+    const page = pageQuery ? parseInt(pageQuery) : DEFAULT_PAGE
     const from = (page - 1) * maxItemsPerPage
     const to = from + maxItemsPerPage - 1
 

--- a/react/utils/search.js
+++ b/react/utils/search.js
@@ -1,3 +1,5 @@
+import { identity } from 'ramda'
+
 export const SORT_OPTIONS = [
   {
     value: 'OrderByTopSaleDESC',
@@ -29,19 +31,16 @@ export const SORT_OPTIONS = [
   },
 ]
 
-export function createMap(params, rest, isBrand) {
-  const paramValues = Object.keys(params)
-    .filter(param => !param.startsWith('_'))
-    .map(key => params[key])
-    .concat(rest ? rest.split(',') : [])
-  const map =
-    paramValues.length > 0 &&
-    Array(paramValues.length - 1)
-      .fill('c')
-      .join(',') +
-    (paramValues.length > 1 ? ',' : '') +
-    (isBrand ? 'b' : 'c')
-  return map
+export function createInitialMap(params) {
+  const map = [
+    params.term && 'ft',
+    params.brand && 'b',
+    params.department && 'c',
+    params.category && 'c',
+    params.subcategory && 'c',
+  ]
+
+  return map.filter(identity).join(',')
 }
 
 export const canonicalPathFromParams = ({


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the default of mapping the params to a category type to mapping each one to it's own corresponding type.

#### What problem is this solving?
On a brand page (such as [this one](https://storecomponents.myvtex.com/google/b)), the query is being made with a category type, instead of brand, which results in no product being found, thus all the products are returned from the api.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/google/b).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
