### PR TITLE
Feature(orderForm): query shippingData and create updateOrderFormShipping mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Enables querying of `shippingData` in `orderFormQuery`
+- Adds `updateOrderFormShipping`, a mutation and function on `OrderFormContext`
 
 ## [1.18.1] - 2018-09-27
 ### Fixed

--- a/react/OrderFormContext.js
+++ b/react/OrderFormContext.js
@@ -8,22 +8,7 @@ import updateItemsMutation from './mutations/updateItemsMutation.gql'
 import updateOrderFormProfile from './mutations/updateOrderFormProfile.gql'
 import updateOrderFormShipping from './mutations/updateOrderFormShipping.gql'
 
-const defaultState = {
-  orderFormContext: {
-    message: { isSuccess: null, text: null },
-    loading: true,
-    orderForm: {},
-    refetch: () => {},
-    addItem: () => {},
-    updateToastMessage: () => {},
-    updateOrderForm: () => {},
-    updateAndRefetchOrderForm: () => {},
-    updateOrderFormProfile: () => {},
-    updateOrderFormShipping: () => {}
-  },
-}
-
-const { Consumer, Provider } = React.createContext(defaultState)
+const { Consumer, Provider } = React.createContext({})
 
 function orderFormConsumer(WrappedComponent) {
   return class OrderFormContext extends Component {
@@ -45,7 +30,20 @@ class ContextProvider extends Component {
     children: PropTypes.element,
   }
 
-  state = defaultState
+  state = {
+    orderFormContext: {
+      message: { isSuccess: null, text: null },
+      loading: true,
+      orderForm: {},
+      refetch: () => {},
+      addItem: this.props.addItem,
+      updateToastMessage: this.handleMessageUpdate,
+      updateOrderForm: this.props.updateOrderForm,
+      updateAndRefetchOrderForm: this.handleUpdateAndRefetchOrderForm,
+      updateOrderFormProfile: this.props.updateOrderFormProfile,
+      updateOrderFormShipping: this.props.updateOrderFormShipping,
+    },
+  }
 
   static getDerivedStateFromProps(props, state) {
     if (!props.data.loading && !props.data.error) {
@@ -58,7 +56,7 @@ class ContextProvider extends Component {
       }
     }
 
-    return defaultState
+    return state
   }
 
   handleUpdateAndRefetchOrderForm = vars => {
@@ -132,7 +130,7 @@ export const OrderFormProvider = compose(
   graphql(addToCartMutation, { name: 'addItem' }),
   graphql(updateItemsMutation, { name: 'updateOrderForm' }),
   graphql(updateOrderFormProfile, { name: 'updateOrderFormProfile' }),
-  graphql(updateOrderFormShipping, { name: 'updateOrderFormShipping'})
+  graphql(updateOrderFormShipping, { name: 'updateOrderFormShipping' })
 )(ContextProvider)
 
 export default { orderFormConsumer, contextPropTypes }

--- a/react/OrderFormContext.js
+++ b/react/OrderFormContext.js
@@ -122,6 +122,25 @@ const contextPropTypes = PropTypes.shape({
     value: PropTypes.number,
     /* Items in the mini cart */
     items: PropTypes.arrayOf(PropTypes.object),
+    /* Shipping Address */
+    shippingData: PropTypes.shape({
+      address: PropTypes.shape({
+        addressName: PropTypes.string,
+        addressType: PropTypes.string,
+        city: PropTypes.string,
+        complement: PropTypes.string,
+        country: PropTypes.string,
+        id: PropTypes.string,
+        neighborhood: PropTypes.string,
+        number: PropTypes.string,
+        postalCode: PropTypes.string,
+        receiverName: PropTypes.string,
+        reference: PropTypes.string,
+        state: PropTypes.string,
+        street: PropTypes.string,
+        userId: PropTypes.string,
+      }),
+    }),
   }),
 }).isRequired
 

--- a/react/OrderFormContext.js
+++ b/react/OrderFormContext.js
@@ -6,6 +6,7 @@ import orderFormQuery from './queries/orderFormQuery.gql'
 import addToCartMutation from './mutations/addToCartMutation.gql'
 import updateItemsMutation from './mutations/updateItemsMutation.gql'
 import updateOrderFormProfile from './mutations/updateOrderFormProfile.gql'
+import updateOrderFormShipping from './mutations/updateOrderFormShipping.gql'
 
 const defaultState = {
   orderFormContext: {
@@ -18,6 +19,7 @@ const defaultState = {
     updateOrderForm: () => {},
     updateAndRefetchOrderForm: () => {},
     updateOrderFormProfile: () => {},
+    updateOrderFormShipping: () => {}
   },
 }
 
@@ -80,6 +82,7 @@ class ContextProvider extends Component {
     state.orderFormContext.updateOrderForm = this.props.updateOrderForm
     state.orderFormContext.addItem = this.props.addItem
     state.orderFormContext.updateOrderFormProfile = this.props.updateOrderFormProfile
+    state.orderFormContext.updateOrderFormShipping = this.props.updateOrderFormShipping
 
     return <Provider value={this.state}>{this.props.children}</Provider>
   }
@@ -111,6 +114,8 @@ const contextPropTypes = PropTypes.shape({
   updateAndRefetchOrderForm: PropTypes.func.isRequired,
   /* Function to update the message */
   updateToastMessage: PropTypes.func.isRequired,
+  /* Function to update the shipping data */
+  updateOrderFormShipping: PropTypes.func.isRequired,
   /* Order form */
   orderForm: PropTypes.shape({
     /* Order form id */
@@ -126,7 +131,8 @@ export const OrderFormProvider = compose(
   graphql(orderFormQuery, options),
   graphql(addToCartMutation, { name: 'addItem' }),
   graphql(updateItemsMutation, { name: 'updateOrderForm' }),
-  graphql(updateOrderFormProfile, { name: 'updateOrderFormProfile' })
+  graphql(updateOrderFormProfile, { name: 'updateOrderFormProfile' }),
+  graphql(updateOrderFormShipping, { name: 'updateOrderFormShipping'})
 )(ContextProvider)
 
 export default { orderFormConsumer, contextPropTypes }

--- a/react/mutations/updateOrderFormShipping.gql
+++ b/react/mutations/updateOrderFormShipping.gql
@@ -1,0 +1,8 @@
+mutation updateOrderFormShipping(
+  $orderFormId: String
+  $address: OrderFormAddressInput
+) {
+  updateOrderFormShipping(orderFormId: $orderFormId, address: $address) {
+    orderFormId
+  }
+}

--- a/react/mutations/updateOrderFormShipping.gql
+++ b/react/mutations/updateOrderFormShipping.gql
@@ -4,5 +4,23 @@ mutation updateOrderFormShipping(
 ) {
   updateOrderFormShipping(orderFormId: $orderFormId, address: $address) {
     orderFormId
+    shippingData {
+      address {
+        id
+        street
+        number
+        receiverName
+        complement
+        neighborhood
+        country
+        state
+        geoCoordinate
+        postalCode
+        city
+        reference
+        addressName
+        addressType
+      }
+    }
   }
 }

--- a/react/queries/orderFormQuery.gql
+++ b/react/queries/orderFormQuery.gql
@@ -12,5 +12,19 @@ query orderForm {
       sellingPrice
       listPrice
     }
+    shippingData {
+      address {
+        id
+        neighborhood
+        complement
+        number
+        street
+        postalCode
+        city
+        reference
+        addressName
+        addressType
+      }
+    }
   }
 }


### PR DESCRIPTION
*NOTE:* This PR is dependant on [store-graphql#134](https://github.com/vtex-apps/store-graphql/pull/134) approval

#### What is the purpose of this pull request?
Adds `shippingData` to the orderForm context query and enables updating the shipping with the function `updateORderFormShipping`

#### What problem is this solving?
For the app `address-locator` and `delivery-dreamstore`, we need to be able to read and update the shippingData, with the purpose of changing the delivery address.

#### How should this be manually tested?
On any app that has the HOC `vtex.store/OrderFormContext`, check that it can now read shippingData values and update it with `props.orderFormContext.updateOrderFormShipping`

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
