### PR TITLE
Fix partial product preview (naively)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.19.4] - 2018-10-1
 ### Fixed
 - Fix partial product preview.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix partial product preview.
+
 ### Added
 - Enables querying of `shippingData` in `orderFormQuery`
 - Adds `updateOrderFormShipping`, a mutation and function on `OrderFormContext`

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.19.3",
+  "version": "1.19.4",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -169,7 +169,12 @@ class ProductContextProvider extends Component {
       fragment: productPreviewFragment,
     })
     const loadedProduct = this.product()
-    const product = loadedProduct ? loadedProduct : productPreview
+    const product = loadedProduct
+      ? loadedProduct
+      : productPreview && productPreview.items
+        ? productPreview
+        : null
+
     const loading = this.loading()
     const { titleTag, metaTagDescription } = product || {}
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
It fixes product preview.

#### What problem is this solving?
We use `readFragment` to get cached product data directly from apollo storage and enable rendering a preview while we wait for product query completion.

But `readFragment` does not grant that every fragment field will be loaded. This creates an issue when we provide incomplete product data to children components, that crashes when trying to access some missing fields. It is happening right now if the recommendations query finishes before the product query, adding an incomplete product data to apollo storage and leading to this error.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
