### PR TITLE
Export store's queries to allow import in other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.21.0] - 2018-10-02
 ### Added
 - Export queries by using an entrypoint
 - Sessions query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Export queries by using an entrypoint
+- Sessions query
 
 ## [1.20.0] - 2018-10-02
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/Queries.js
+++ b/react/Queries.js
@@ -1,0 +1,13 @@
+import session from './queries/sessionQuery.gql'
+import orderForm from './queries/orderFormQuery.gql'
+import product from './queries/productQuery.gql'
+import recommendatinsAndBenefits from './queries/recommendationsAndBenefitsQuery.gql'
+import search from './queries/searchQuery.gql'
+
+export default {
+  orderForm,
+  product,
+  recommendatinsAndBenefits,
+  search,
+  session,
+}

--- a/react/queries/sessionQuery.gql
+++ b/react/queries/sessionQuery.gql
@@ -1,0 +1,23 @@
+query Session {
+  getSession {
+    id
+    adminUserId
+    impersonable
+    adminUserEmail
+    profile {
+      id
+      firstName
+      lastName
+      email
+    }
+    impersonate {
+      profile {
+        phone
+        email
+        lastName
+        document
+        firstName
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Other modules may want to use vtex.store's queries. This PR enables this functionality by exporting all queries in an entrypoint and adding a new `Sessions` query

#### How should this be manually tested?
Link this module along with [telemarketing](https://github.com/vtex-apps/telemarketing/pull/11) and [login](https://github.com/vtex-apps/login/pull/67) and use the session functionalities

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
