### PR TITLE
Enable querying of availableAddresses in orderFormQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Enables querying of `availableAddresses` in `orderFormQuery`
 
 ## [1.21.0] - 2018-10-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.22.0] - 2018-10-11
 ### Added
 - Enables querying of `availableAddresses` in `orderFormQuery`
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/OrderFormContext.js
+++ b/react/OrderFormContext.js
@@ -140,6 +140,7 @@ const contextPropTypes = PropTypes.shape({
         street: PropTypes.string,
         userId: PropTypes.string,
       }),
+      /* Available Addresses */
       availableAddresses: PropTypes.arrayOf(PropTypes.object),
     }),
   }),

--- a/react/OrderFormContext.js
+++ b/react/OrderFormContext.js
@@ -140,6 +140,7 @@ const contextPropTypes = PropTypes.shape({
         street: PropTypes.string,
         userId: PropTypes.string,
       }),
+      availableAddresses: PropTypes.arrayOf(PropTypes.object),
     }),
   }),
 }).isRequired

--- a/react/queries/orderFormQuery.gql
+++ b/react/queries/orderFormQuery.gql
@@ -31,6 +31,18 @@ query orderForm {
         addressName
         addressType
       }
+      availableAddresses {
+        id
+        neighborhood
+        complement
+        number
+        street
+        postalCode
+        city
+        reference
+        addressName
+        addressType
+      }
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enable querying of `availableAddresses` in `orderFormQuery`

#### What problem is this solving?

The needing of [address-locator](https://github.com/vtex-apps/address-locator) component to have functionalities using the available addresses

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
