### PR TITLE
Add extension container for pixel apps

### DIFF
--- a/pages/pages.json
+++ b/pages/pages.json
@@ -45,5 +45,10 @@
       "canonical": "/:term",
       "context": "ProductSearchContextProvider"
     }
+  },
+  "extensions": {
+    "store/pixel": {
+      "component": "vtex.render-runtime/ExtensionContainer"
+    }
   }
 }

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Helmet, withRuntimeContext } from 'render'
+import { Helmet, withRuntimeContext, ExtensionPoint } from 'render'
 import PropTypes from 'prop-types'
 
 import GtmScripts from './components/GtmScripts'
@@ -43,6 +43,7 @@ class StoreContextProvider extends Component {
       <PixelProvider>
         <DataLayerProvider value={{ dataLayer: window.dataLayer }}>
           <GtmScripts gtmId={gtmId} />
+          <ExtensionPoint id="store/pixel" />
           <PageViewPixel />
           <Helmet>
             <title>{titleTag}</title>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `ExtensionContainer` in a extension point to be able to add pixel apps automatically.

#### What problem is this solving?
Before, the store owner would need to manually add pixel apps to the `pages.json`.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/), the facebook pixel app is being inserted automatically.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
