### PR TITLE
Query email on orderForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.26.1] - 2018-11-01
 ### Added
 - Field `clientProfileData.email` in `orderFormQuery`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Field `clientProfileData.email` in `orderFormQuery`
 
 ## [1.26.0] - 2018-10-24
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/queries/orderFormQuery.gql
+++ b/react/queries/orderFormQuery.gql
@@ -44,5 +44,8 @@ query orderForm {
         addressType
       }
     }
+    clientProfileData {
+      email
+    }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds field `clientProfileData.email` to `orderFormQuery`

#### What problem is this solving?
`vtex.rebuy` needs to know the user email from orderForm to get his last order from MasterData

#### How should this be manually tested?
N/A

#### Screenshots or example usage
Used for this PR: https://github.com/vtex-apps/rebuy/pull/1

#### Types of changes
* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.