### PR TITLE
Remove isRequired from contextPropTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Removed `isRequired` from `orderFormContext` propTypes
+
 ## [1.26.0] - 2018-10-24
 
 ## [1.25.1] - 2018-10-18

--- a/react/OrderFormContext.js
+++ b/react/OrderFormContext.js
@@ -144,7 +144,7 @@ const contextPropTypes = PropTypes.shape({
       availableAddresses: PropTypes.arrayOf(PropTypes.object),
     }),
   }),
-}).isRequired
+})
 
 export const OrderFormProvider = compose(
   graphql(orderFormQuery, options),


### PR DESCRIPTION
#### What is the purpose of this pull request?

Removed `isRequired` from `contextPropTypes`
It should be left to the "user", so to speak, to decide whether it's required or not.

