### PR TITLE
replace system routes to use canonicals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.33.0] - 2018-12-03
+
 ## [1.32.0] - 2018-12-02
 ### Added
 - Support to PWA. 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'ramda'
+import { isEmpty, path } from 'ramda'
 import React, { Component, Fragment } from 'react'
 import { Helmet, withRuntimeContext, ExtensionPoint } from 'render'
 import PropTypes from 'prop-types'
@@ -62,6 +62,7 @@ class StoreContextProvider extends Component {
     const {
       runtime: {
         culture: { country, locale, currency },
+        history,
         pages,
         page,
         route,
@@ -88,6 +89,10 @@ class StoreContextProvider extends Component {
 
     if (!canonicalPath && !isEmpty(params) && canonicalTemplate) {
       canonicalPath = canonicalPathFromParams(canonicalTemplate, params)
+      const pathname = path(['location', 'pathname'], history)
+      if (pathname && canonicalPath && canonicalPath !== pathname) {
+        history.replace(canonicalPath, { ...history.location, renderRouting: true, route })
+      }
     }
 
     return (


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR prevents the browser's history from showing system routes on client-side navigation. It does so by replacing these routes with canonical urls. For example, if we navigate to 
Depends on: https://github.com/vtex-apps/render-runtime/pull/163

`/my-favorite-brand/b`, this route will be replaced with `/my-favorite-brand`

#### What problem is this solving?
Many people have complained about having the `/b, /d, /s` in the end of conflicting routes. This PR address this problem by artificially replacing these terminations with their canonical representations

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
