### PR TITLE
Add option to search query to exclude facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.29.0] - 2018-11-16
 ### Added
 - Add optional param to search query to determine if the `facets` should be included.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add optional param to search query to determine if the `facets` should be included.
 
 ## [1.28.2] - 2018-11-14
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.28.2",
+  "version": "1.29.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -159,19 +159,21 @@ class ProductSearchContextProvider extends Component {
     const from = (page - 1) * maxItemsPerPage
     const to = from + maxItemsPerPage - 1
 
-    const includeFacets = map => !!(map && map.length > 0)
+    const includeFacets = (map, query) => !!(map && map.length > 0 && query && query.length > 0)
+
+    const query = Object.values(params)
+      .filter(s => s.length > 0)
+      .join('/')
 
     const defaultSearch = {
-      query: Object.values(params)
-        .filter(s => s.length > 0)
-        .join('/'),
+      query,
       map,
       rest,
       orderBy,
       priceRange,
       from,
       to,
-      withFacets: includeFacets(map),
+      withFacets: includeFacets(map, query),
     }
 
     const customSearch = {
@@ -182,7 +184,7 @@ class ProductSearchContextProvider extends Component {
       priceRange,
       from,
       to,
-      withFacets: includeFacets(mapField),
+      withFacets: includeFacets(mapField, queryField),
     }
 
     return (

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -34,6 +34,14 @@ class ProductSearchContextProvider extends Component {
       order: PropTypes.oneOf(SORT_OPTIONS.map(o => o.value)),
       priceRange: PropTypes.string,
     }),
+    /** Custom query `query` param */
+    queryField: PropTypes.string,
+    /** Custom query `map` param */
+    mapField: PropTypes.string,
+    /** Custom query `rest` param */
+    restField: PropTypes.string,
+    /** Custom query `orderBy` param */
+    orderByField: PropTypes.string,
     /** Current extension point name */
     nextTreePath: PropTypes.string,
     /** Component to be rendered */
@@ -151,6 +159,8 @@ class ProductSearchContextProvider extends Component {
     const from = (page - 1) * maxItemsPerPage
     const to = from + maxItemsPerPage - 1
 
+    const includeFacets = map => !!(map && map.length > 0)
+
     const defaultSearch = {
       query: Object.values(params)
         .filter(s => s.length > 0)
@@ -161,6 +171,7 @@ class ProductSearchContextProvider extends Component {
       priceRange,
       from,
       to,
+      withFacets: includeFacets(map),
     }
 
     const customSearch = {
@@ -171,6 +182,7 @@ class ProductSearchContextProvider extends Component {
       priceRange,
       from,
       to,
+      withFacets: includeFacets(mapField),
     }
 
     return (

--- a/react/queries/searchQuery.gql
+++ b/react/queries/searchQuery.gql
@@ -1,8 +1,8 @@
-query search($query: String, $map: String, $rest: String, $orderBy: String, $priceRange: String, $from: Int, $to: Int) {
+query search($query: String, $map: String, $rest: String, $orderBy: String, $priceRange: String, $from: Int, $to: Int, $withFacets: Boolean = true) {
   search(query: $query, map: $map, rest: $rest, orderBy: $orderBy, priceRange: $priceRange, from: $from, to: $to) {
     titleTag
     metaTagDescription
-    facets {
+    facets @include (if: $withFacets) {
       Departments {
         Quantity
         Name


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add option to the search query, so the client is able to skip the `facets`.

#### What problem is this solving?
See [vtex/store-graphql#169](https://github.com/vtex-apps/store-graphql/pull/169).

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
