### PR TITLE
Move canonical url to store context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.28.2] - 2018-11-14
 ### Changed
 - Move the canonical link to the store context, so it's applied to all pages.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Move the canonical link to the store context, so it's applied to all pages.
 
 ## [1.28.1] - 2018-11-13
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/ProductSearchContextProvider.js
+++ b/react/ProductSearchContextProvider.js
@@ -6,7 +6,6 @@ import { Helmet, withRuntimeContext } from 'render'
 import DataLayerApolloWrapper from './components/DataLayerApolloWrapper'
 import searchQuery from './queries/searchQuery.gql'
 import {
-  canonicalPathFromParams,
   createInitialMap,
   SORT_OPTIONS,
 } from './utils/search'
@@ -196,12 +195,6 @@ class ProductSearchContextProvider extends Component {
               loading={loading}
             >
               <Helmet>
-                {params && (
-                  <link
-                    rel="canonical"
-                    href={`https://${window.__hostname__}${canonicalPathFromParams(params)}`}
-                  />
-                )}
                 {titleTag && <title>{titleTag}</title>}
                 {metaTagDescription && (
                   <meta name="description" content={metaTagDescription} />

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -81,7 +81,7 @@ class StoreContextProvider extends Component {
               {canonicalPath && (
                 <link
                   rel="canonical"
-                  href={`https://${window.__hostname__}${canonicalPath}`}
+                  href={`https://${window.__hostname__ || window.location && window.location.hostname}${canonicalPath}`}
                 />
               )}
             </Helmet>

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -78,7 +78,12 @@ class StoreContextProvider extends Component {
               <meta name="currency" content={currency} />
               <meta name="robots" content={metaTagRobots || META_ROBOTS} />
               <meta httpEquiv="Content-Type" content={CONTENT_TYPE} />
-              {canonicalPath && <link rel="canonical" href={canonicalPath} />}
+              {canonicalPath && (
+                <link
+                  rel="canonical"
+                  href={`https://${window.__hostname__}${canonicalPathFromParams(params)}`}
+                />
+              )}
             </Helmet>
             <OrderFormProvider>
               <div className="vtex-store__template">{this.props.children}</div>

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -81,7 +81,7 @@ class StoreContextProvider extends Component {
               {canonicalPath && (
                 <link
                   rel="canonical"
-                  href={`https://${window.__hostname__}${canonicalPathFromParams(params)}`}
+                  href={`https://${window.__hostname__}${canonicalPath}`}
                 />
               )}
             </Helmet>

--- a/react/package.json
+++ b/react/package.json
@@ -7,7 +7,8 @@
     "@vtex/styleguide": "^3.0.2",
     "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.5.10",
-    "react-slick": "^0.16.0"
+    "react-slick": "^0.16.0",
+    "route-parser": "^0.0.5"
   },
   "devDependencies": {
     "@types/graphql": "^14.0.1",

--- a/react/utils/canonical.js
+++ b/react/utils/canonical.js
@@ -1,9 +1,7 @@
-import { keys } from 'ramda'
+import RouteParser from 'route-parser'
 
 const canonicalPathFromParams = (canonicalTemplate, params) => {
-  const regex = new RegExp(`:(${keys(params).join('|')})`, 'g')
-
-  return canonicalTemplate.replace(regex, (_, p) => params[p])
+  return new RouteParser(canonicalTemplate).reverse(params)
 }
 
 export default canonicalPathFromParams

--- a/react/utils/canonical.js
+++ b/react/utils/canonical.js
@@ -1,10 +1,7 @@
 import { keys } from 'ramda'
 
 const canonicalPathFromParams = (canonicalTemplate, params) => {
-  console.log(params)
   const regex = new RegExp(`:(${keys(params).join('|')})`, 'g')
-
-  console.log(regex)
 
   return canonicalTemplate.replace(regex, (_, p) => params[p])
 }

--- a/react/utils/canonical.js
+++ b/react/utils/canonical.js
@@ -1,0 +1,12 @@
+import { keys } from 'ramda'
+
+const canonicalPathFromParams = (canonicalTemplate, params) => {
+  console.log(params)
+  const regex = new RegExp(`:(${keys(params).join('|')})`, 'g')
+
+  console.log(regex)
+
+  return canonicalTemplate.replace(regex, (_, p) => params[p])
+}
+
+export default canonicalPathFromParams

--- a/react/utils/search.js
+++ b/react/utils/search.js
@@ -42,13 +42,3 @@ export function createInitialMap(params) {
 
   return map.filter(identity).join(',')
 }
-
-export const canonicalPathFromParams = ({
-  brand,
-  department,
-  category,
-  subcategory,
-}) =>
-  ['', brand || department, category, subcategory].reduce(
-    (acc, curr) => (curr ? `${acc}/${curr}` : acc)
-  )

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4458,6 +4458,11 @@ rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
+route-parser@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/route-parser/-/route-parser-0.0.5.tgz#7d1d09d335e49094031ea16991a4a79b01bbe1f4"
+  integrity sha1-fR0J0zXkkJQDHqFpkaSnmwG74fQ=
+
 rst-selector-parser@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Move the insertion of `<link rel="canonical" />` to the store context, so it's applied to all pages.

#### What problem is this solving?
The canonical url existed only in the search pages.

#### How should this be manually tested?
[Workspace](https://canonicalpath--storecomponents.myvtex.com/iphone-xs).

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
