### PR TITLE
Fix canonical path replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.33.1] - 2018-12-05
 ### Fixed
 - Fix canonical path replace to include query parameters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix canonical path replace to include query parameters.
 
 ## [1.33.0] - 2018-12-03
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -50,8 +50,8 @@ class StoreContextProvider extends Component {
   componentDidMount() {
     const {
       runtime: {
-        prefetchDefaultPages
-      }
+        prefetchDefaultPages,
+      },
     } = this.props
     prefetchDefaultPages([
       'store/product',
@@ -91,7 +91,10 @@ class StoreContextProvider extends Component {
       canonicalPath = canonicalPathFromParams(canonicalTemplate, params)
       const pathname = path(['location', 'pathname'], history)
       if (pathname && canonicalPath && canonicalPath !== pathname) {
-        history.replace(canonicalPath, { ...history.location, renderRouting: true, route })
+        history.replace(`${canonicalPath}${history.location.search}`, {
+          renderRouting: true,
+          route,
+        })
       }
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Include the `history.location.search` in the path replaced.

#### What problem is this solving?
On department screens, the path replaced removed the query parameters.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/decoration).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
