### PR TITLE
Fix http-equiv meta tag content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Content of `meta http-equiv` tag (missing space).
 
 ## [1.33.2] - 2018-12-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.33.3] - 2018-12-11
 ### Fixed
 - Content of `meta http-equiv` tag (missing space).
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "1.33.2",
+  "version": "1.33.3",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/StoreContextProvider.js
+++ b/react/StoreContextProvider.js
@@ -14,7 +14,7 @@ import { PixelProvider } from './PixelContext'
 import pwaDataQuery from './queries/pwaDataQuery.gql'
 
 const APP_LOCATOR = 'vtex.store'
-const CONTENT_TYPE = 'text/html;charset=utf-8'
+const CONTENT_TYPE = 'text/html; charset=utf-8'
 const META_ROBOTS = 'index, follow'
 const MOBILE_SCALING = 'width=device-width, initial-scale=1'
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add missing space before charset definition.

#### What problem is this solving?
The value without the space is considered invalid by the AMP Validator.

#### How should this be manually tested?
**⚠️ Caution:** here be dragons, [workspace](https://lucas--storecomponents.myvtex.com/clothing?__amp).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
