### PR TITLE
Add missing productReference field to the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Missing `productReference` field for the ProductContext
+
 ## [1.35.2] - 2019-01-14
 
 ### Changed

--- a/react/queries/productQuery.gql
+++ b/react/queries/productQuery.gql
@@ -11,6 +11,7 @@ query Product($slug: String) {
     categoryId
     categoriesIds
     brand
+    productReference
     properties {
       name
       values


### PR DESCRIPTION
#### What is the purpose of this pull request?
Query the productReference field and provide it to ProductContext

#### What problem is this solving?
The app `vtex.product-details` at the current stable version (`0.8.3`) has an option on it's schema to show the reference of the product, but it's not rendered because it never gets the necessary data to pass as props to `vtex.store-components/ProductName`.

#### How should this be manually tested?
https://dan--schuster.myvtex.com/gabinete-para-bomba-de-vacuo/p

#### Screenshots or example usage
![screenshot at jan 14 15-14-48](https://user-images.githubusercontent.com/27775611/51128618-74859b80-180f-11e9-94ef-41b7f6ddb7ef.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
