### PR TITLE
Remove usage of old context API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.5] - 2019-02-08
 ### Changed
 - Removed usage of old context api.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removed usage of old context api.
 
 ## [2.0.4] - 2019-02-08
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -92,9 +92,10 @@ class StoreWrapper extends Component {
         pages,
         page,
         route,
+        getSettings,
       },
     } = this.props
-    const settings = this.context.getSettings(APP_LOCATOR) || {}
+    const settings = getSettings(APP_LOCATOR) || {}
     const {
       titleTag,
       metaTagDescription,
@@ -171,10 +172,6 @@ class StoreWrapper extends Component {
       </Fragment>
     )
   }
-}
-
-StoreWrapper.contextTypes = {
-  getSettings: PropTypes.func,
 }
 
 export default graphql(pwaDataQuery)(withRuntimeContext(StoreWrapper))


### PR DESCRIPTION
#### What is the purpose of this pull request?
Replace the usage of the old context api (using `contextType`) to use the function provided in the `runtime` prop.

#### What problem is this solving?
This will give a warning when running in strict mode.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
