### PR TITLE
All sku should be an offer in microdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- All sku presents in a product now is rendered as offer in `MicroData`.
+
 ### Added
 - Add SKU id in Product's microdata. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed 
-- All sku presents in a product now is rendered as offer in `MicroData`.
+- Now, SKU list is rendered as an offer in `MicroData`.
 
 ### Added
 - Add SKU id in Product's microdata. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.0] - 2019-02-12
 ### Fixed 
 - Now, SKU list is rendered as an offer in `MicroData`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/components/MicroData.js
+++ b/react/components/MicroData.js
@@ -26,7 +26,6 @@ const lowestPriceInStockSKU = sku => {
     sku,
     seller: lowestPriceInStockSeller(sku)
   }]
-
   const { item, seller } = lowestPriceItem(itemSeller)
 
   return {
@@ -47,7 +46,6 @@ const tryParsingLocale = (description, locale) => {
 }
 
 const renderOffer = (item, currency) => {
-
 
   const { seller } = lowestPriceInStockSKU(item)
 

--- a/react/components/MicroData.js
+++ b/react/components/MicroData.js
@@ -21,27 +21,6 @@ const lowestPriceItem = compose(
   sort((itemA, itemB) => (path(['seller', 'commertialOffer', 'Price'], itemA) - path(['seller', 'commertialOffer', 'Price'], itemB)))
 )
 
-const lowestPriceInStock = (product, skuId) => {
-  const skuItemFilter = item => path(['item', 'itemId'], item) === skuId
-  const items = map(item => ({
-    item,
-    seller: lowestPriceInStockSeller(item),
-  }), product.items)
-
-
-  const filteredItems = filter(skuItemFilter, items)
-
-  const { item, seller } = lowestPriceItem(filteredItems)
-
-  const image = head(item.images)
-
-  return {
-    item,
-    image,
-    seller,
-  }
-}
-
 const lowestPriceInStockSKU = sku => {
   const itemSeller = [{
     sku,
@@ -62,14 +41,13 @@ const tryParsingLocale = (description, locale) => {
     const descriptionObject = JSON.parse(description)
     parsedDescription = descriptionObject[locale] || descriptionObject[head(split('-', locale))]
   } catch (e) {
-    console.log('Failed to parse multilanguage product description')
+    console.warn('Failed to parse multilanguage product description')
   }
   return parsedDescription || description
 }
 
 const renderOffer = (item, currency) => {
 
-  console.log(lowestPriceInStockSKU(item))
 
   const { seller } = lowestPriceInStockSKU(item)
 
@@ -97,7 +75,6 @@ const renderOffer = (item, currency) => {
 export default function MicroData({ product, query }, { culture: { currency, locale } }) {
   const skuId = query.skuId || path(['items', '0', 'itemId'], product)
   const image = head(path(['items', '0', 'images'], product))
-  const { seller } = lowestPriceInStock(product, skuId)
   return (
     <div className="dn" vocab="http://schema.org/" typeof="Product">
       <span property="brand">{product.brand}</span>
@@ -111,23 +88,6 @@ export default function MicroData({ product, query }, { culture: { currency, loc
           {renderOffer(item, currency)}
         </Fragment>
       ))}
-      {/* <span property="offers" typeof="Offer">
-        <meta property="priceCurrency" content={currency} />
-        <span property="sku">{skuId}</span>
-        $<span property="price">{path(['commertialOffer', 'Price'], seller)}</span>
-        (Sale ends <time property="priceValidUntil" dateTime={path(['commertialOffer', 'PriceValidUntil'], seller)}>
-          {path(['commertialOffer', 'PriceValidUntil'], seller)}
-        </time>)
-        Available from: <span property="seller" typeof="Organization"
-        >
-          <span property="name">{seller.sellerName}</span>
-        </span>
-        Condition: <link property="itemCondition" href="http://schema.org/NewCondition" />New
-        {pathOr(ITEM_AVAILABLE, ['commertialOffer', 'AvailableQuantity'], seller)
-          ? <Fragment><link property="availability" href="http://schema.org/InStock"></link> In stock. Order now.</Fragment>
-          : <Fragment><link property="availability" href="http://schema.org/OutOfStock"></link>Out of Stock</Fragment>
-        }
-      </span> */}
     </div>
   )
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Render all the sku's like a offer's microdata. 

#### How should this be manually tested?
https://mdsku--storecomponents.myvtex.com/


#### Screenshots or example usage
Go to the  [google test tool](https://search.google.com/structured-data/testing-tool) and paste the source code from the page of a product (the product needs have more than one sku). Note that has more than one field offer.
#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
