### PR TITLE
Highlight overlay on store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.0] - 2019-02-15
 ### Added
 - `highlight-overlay` to `storeWrapper` allowed interfaces and corresponding `ExtensionPoint` to `StoreWrapper` implementation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `highlight-overlay` to `storeWrapper` allowed interfaces and corresponding `ExtensionPoint` to `StoreWrapper` implementation.
 
 ## [2.1.2] - 2019-02-14
 
 ## [2.1.1] - 2019-02-14
 
 ## [2.1.0] - 2019-02-12
-### Fixed 
+### Fixed
 - Now, SKU list is rendered as an offer in `MicroData`.
 
 ### Added
-- Add SKU id in Product's microdata. 
+- Add SKU id in Product's microdata.
 
-### Fixed 
+### Fixed
 - Only seller that has match with the skuId can sell the item.
 
 ## [2.0.5] - 2019-02-08

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -1,11 +1,10 @@
 import { path } from 'ramda'
 import React, { Component, Fragment } from 'react'
-import { canUseDOM, Helmet, withRuntimeContext } from 'vtex.render-runtime'
+import { canUseDOM, ExtensionPoint, Helmet, NoSSR, withRuntimeContext  } from 'vtex.render-runtime'
 import PropTypes from 'prop-types'
 import { graphql } from 'react-apollo'
 import { PixelProvider } from 'vtex.pixel-manager/PixelContext'
 import PixelManager from 'vtex.pixel-manager/PixelManager'
-import { NoSSR, ExtensionPoint } from 'vtex.render-runtime'
 import { ToastProvider } from 'vtex.styleguide'
 
 import canonicalPathFromParams from './utils/canonical'

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -1,7 +1,6 @@
-import { canUseDOM } from 'exenv'
 import { path } from 'ramda'
 import React, { Component, Fragment } from 'react'
-import { Helmet, withRuntimeContext } from 'vtex.render-runtime'
+import { canUseDOM, Helmet, withRuntimeContext } from 'vtex.render-runtime'
 import PropTypes from 'prop-types'
 import { graphql } from 'react-apollo'
 import { PixelProvider } from 'vtex.pixel-manager/PixelContext'

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -1,3 +1,4 @@
+import { canUseDOM } from 'exenv'
 import { path } from 'ramda'
 import React, { Component, Fragment } from 'react'
 import { Helmet, withRuntimeContext } from 'vtex.render-runtime'
@@ -5,6 +6,7 @@ import PropTypes from 'prop-types'
 import { graphql } from 'react-apollo'
 import { PixelProvider } from 'vtex.pixel-manager/PixelContext'
 import PixelManager from 'vtex.pixel-manager/PixelManager'
+import { NoSSR, ExtensionPoint } from 'vtex.render-runtime'
 import { ToastProvider } from 'vtex.styleguide'
 
 import canonicalPathFromParams from './utils/canonical'
@@ -74,6 +76,8 @@ class StoreWrapper extends Component {
       }),
     }),
   }
+
+  isStorefrontIframe = canUseDOM && window.top !== window.self && window.top.__provideRuntime
 
   componentDidMount() {
     const {
@@ -169,6 +173,11 @@ class StoreWrapper extends Component {
             </ToastProvider>
           </DataLayerProvider>
         </PixelProvider>
+        {this.isStorefrontIframe && (
+          <NoSSR>
+            <ExtensionPoint id="highlight-overlay" />
+          </NoSSR>
+        )}
       </Fragment>
     )
   }

--- a/react/package.json
+++ b/react/package.json
@@ -4,6 +4,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "exenv": "^1.2.2",
     "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.5.10",
     "ramda": "^0.26.1",

--- a/react/package.json
+++ b/react/package.json
@@ -4,7 +4,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "exenv": "^1.2.2",
     "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.5.10",
     "ramda": "^0.26.1",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -21,9 +21,6 @@
       "type": "block"
     }
   },
-  "highlight-overlay": {
-    "component": "*"
-  },
   "store.home": {
     "around": [
       "homeWrapper"
@@ -95,6 +92,10 @@
   "challenge": {
     "component": "DefaultChallenge",
     "extensible": "public"
+  },
+  "highlight-overlay": {
+    "component": "*",
+    "extensible": "vtex"
   },
   "challenge.profile": {
     "component": "ProfileChallenge"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -21,6 +21,9 @@
       "type": "block"
     }
   },
+  "highlight-overlay": {
+    "component": "*"
+  },
   "store.home": {
     "around": [
       "homeWrapper"
@@ -77,6 +80,7 @@
     ]
   },
   "storeWrapper": {
+    "allowed": ["highlight-overlay"],
     "component": "StoreWrapper"
   },
   "homeWrapper": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Create the interface that will allow `admin-pages`' Storefront to insert the `HighlightOverlay` plugin, which highlights the selected component.

#### What problem is this solving?
This broke when migrating to the new blocks architecture.

#### Types of changes
* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
