### PR TITLE
Adds store-sitemap as peer dependency of store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.7.0] - 2019-03-08
+
 ## [2.6.0] - 2019-03-01
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
     "postreleasy": "vtex publish --verbose"
   },
   "peerDependencies": {
-    "vtex.store-sitemap": "1.x"
+    "vtex.store-sitemap": "1.x",
+    "vtex.request-capture": "1.x"
   },
   "dependencies": {
     "vtex.store-graphql": "2.x",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,9 @@
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },
+  "peerDependencies": {
+    "vtex.store-sitemap": "1.x"
+  },
   "dependencies": {
     "vtex.store-graphql": "2.x",
     "vtex.store-resources": "0.x",


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds store-sitemap as a peer dependency of `vtex.store`

This means that, to install `vtex.store`, `vtex.store-sitemap` will have to be installed. 

I think this behavior is ok, since `vtex.store-sitemap` is the one having the canonical routes translation map and is a must have for our stores

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
