### PR TITLE
Fix loading icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.1] - 2019-02-21
 ### Fixed
 - Loading icon didn't indicate the loading properly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Loading icon didn't indicate the loading properly.
 
 ## [2.3.0] - 2019-02-20
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/styles/iconpacks/iconpack.svg
+++ b/styles/iconpacks/iconpack.svg
@@ -263,8 +263,9 @@
       <path d="M15,7H1C0.4,7,0,7.4,0,8s0.4,1,1,1h14c0.6,0,1-0.4,1-1S15.6,7,15,7z" fill="currentColor"/>
     </g>
     <g id="sti-loading" className="c-action-primary db">
-      <circle 0="" cx="50" cy="50" fill="none" r="40" stroke="currentColor" strokeWidth="10" strokeDasharray="{`0" ${80="" *="" Math.PI="" 0.75}="" Math.PI}`}="" strokeLinecap="round" strokeDashoffset="1">
-        <animateTransform attributeName="transform" type="rotate" calcMode="linear" values="0 50 50;360 50 50" keyTimes="0;1" dur="0.7s" begin="0s" repeatCount="indefinite"/>
+      <circle cx="50" opacity="0.4" cy="50" fill="none" stroke="currentColor" r="40" class="c-muted-1" stroke-width="14"></circle>
+      <circle cx="50" cy="50" fill="none" stroke="currentColor" r="40" transform="rotate(322.24 50 50)" stroke-dasharray="60 900" stroke-width="12" stroke-linecap="round">
+        <animateTransform type="rotate" values="0 50 50;360 50 50" dur="0.7s" begin="0s" calcMode="linear" repeatCount="indefinite" keyTimes="0;1" attributeName="transform"></animateTransform>
       </circle>
     </g>
     <g id="sti-check--line">


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the loading symbol to be an actual loading spinner.

#### What problem is this solving?
The icon wasn't the right one.

#### How should this be manually tested?
Link this branch in any workspace.

#### Screenshots or example usage

Before
![image](https://user-images.githubusercontent.com/10223856/53191964-faa1b880-35eb-11e9-8b41-39bf842aba93.png)

After
![loading-after](https://user-images.githubusercontent.com/10223856/53192392-1ce80600-35ed-11e9-8b21-0f37f512ec62.gif)

(the gif isn't smooth, but _trust me_)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
