### PR TITLE
Fix className on svg file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Attribute `className` on svg file.
 
 ## [2.3.1] - 2019-02-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.2] - 2019-02-21
 ### Fixed
 - Attribute `className` on svg file.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/styles/iconpacks/iconpack.svg
+++ b/styles/iconpacks/iconpack.svg
@@ -262,7 +262,7 @@
     <g id="nav-minus">
       <path d="M15,7H1C0.4,7,0,7.4,0,8s0.4,1,1,1h14c0.6,0,1-0.4,1-1S15.6,7,15,7z" fill="currentColor"/>
     </g>
-    <g id="sti-loading" className="c-action-primary db">
+    <g id="sti-loading" class="c-action-primary db">
       <circle cx="50" opacity="0.4" cy="50" fill="none" stroke="currentColor" r="40" class="c-muted-1" stroke-width="14"></circle>
       <circle cx="50" cy="50" fill="none" stroke="currentColor" r="40" transform="rotate(322.24 50 50)" stroke-dasharray="60 900" stroke-width="12" stroke-linecap="round">
         <animateTransform type="rotate" values="0 50 50;360 50 50" dur="0.7s" begin="0s" calcMode="linear" repeatCount="indefinite" keyTimes="0;1" attributeName="transform"></animateTransform>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change from `className` to `class` on iconpack svg.

#### What problem is this solving?
The attribute `className` is specific to javascript and doesn't work on the svg.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
