### PR TITLE
Add default orderBy to relevance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.5.2] - 2019-02-25
 ### Fixed
 - Add default orderBy to relevance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add default orderBy to relevance
 
 ## [2.5.1] - 2019-02-25
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/utils/search.js
+++ b/react/utils/search.js
@@ -2,6 +2,10 @@ import { identity } from 'ramda'
 
 export const SORT_OPTIONS = [
   {
+    value: 'OrderBy',
+    label: 'ordenation.choose',
+  },
+  {
     value: 'OrderByTopSaleDESC',
     label: 'ordenation.sales',
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

The default order by should be by relevance of the search or the default of the category.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
