### PR TITLE
Remove address-locator dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.5.6] - 2019-02-26
+
 ### Removed
 - Removed address-locator dependency.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- Removed address-locator dependency.
+
 ## [2.5.5] - 2019-02-26
 ### Added
 - Add favicon's <link> to the store. Configurable through the admin settings.

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,6 @@
     "vtex.search-result": "3.x",
     "vtex.login": "2.x",
     "vtex.my-account": "1.x",
-    "vtex.address-locator": "1.x",
     "vtex.rebuy": "1.x",
     "vtex.pixel-manager": "0.x"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -15,7 +15,6 @@
       "carousel",
       "shelf",
       "rebuy",
-      "address-manager",
       "promo-bar",
       "info-card"
     ],


### PR DESCRIPTION
As the title says.

The address-locator is a different sort of component now—not inserted on every page as a bar and modal, but rather a single page component. Its previous role is now fulfilled by the `user-address` component, located in the `store-components` app.