### PR TITLE
Add the toast persistence logic as we know if there is a toast visible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the toast persistence logic as we know if there is a toast visible.
 
 ## [2.8.0] - 2019-03-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.9.0] - 2019-03-22
 ### Added
 - Add the toast persistence logic as we know if there is a toast visible.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/components/NetworkStatusToast.js
+++ b/react/components/NetworkStatusToast.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types'
-import { compose, pathOr } from 'ramda'
-import React, { useState, useEffect } from 'react'
+import { path, pathOr } from 'ramda'
+import { useContext, useEffect, useState } from 'react'
 import { injectIntl, intlShape } from 'react-intl'
-import { withToast } from 'vtex.styleguide'
+import { ToastContext } from 'vtex.styleguide'
 
 function NetworkStatusToast(props) {
   const toastConfig = {
@@ -14,6 +14,8 @@ function NetworkStatusToast(props) {
   }
 
   const [offline, setOffline] = useState(false)
+  const { showToast, hideToast, toastState } = useContext(ToastContext)
+
   const updateStatus = () => {
     if (navigator) {
       setOffline(!pathOr(true, ['onLine'], navigator))
@@ -35,26 +37,16 @@ function NetworkStatusToast(props) {
   }, [])
 
   useEffect(() => {
-    // TODO: This logic will be possible when the ToastProvider provide the `toastState`
-    // prop to it's Consumers. This way, the toast can be shown when no other toast is visible.
-
-    /* const { toastState } = props
-    if (offline && !toastState.isToastVisible) {
-      props.showToast(toastConfig)
+    if (offline && !toastState.currentToast) {
+      showToast(toastConfig)
     } else if (
       !offline &&
       toastState.isToastVisible &&
-      toastState.currentToast.message === this.toastConfig.message
+      path(['currentToast', 'message'], toastState) === toastConfig.message
     ) {
-      props.hideToast()
-    }*/
-
-    if (offline) {
-      props.showToast(toastConfig)
-    } else {
-      props.hideToast()
+      hideToast()
     }
-  }, [offline])
+  }, [offline, toastState])
 
   return null
 }
@@ -63,11 +55,7 @@ NetworkStatusToast.propTypes = {
   hideToast: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   showToast: PropTypes.func.isRequired,
-  // TODO: Same about toastState
-  // toastState: PropTypes.object.isRequired,
+  toastState: PropTypes.object.isRequired,
 }
 
-export default compose(
-  withToast,
-  injectIntl
-)(NetworkStatusToast)
+export default injectIntl(NetworkStatusToast)


### PR DESCRIPTION
**Depends on vtex/styleguide#581**

#### What is the purpose of this pull request?

Without the `toastState` from the `ToastContext`, we cannot determine whether there is no Toast been shown to show the offline toast. This way, when a toast pops up and then goes away, the offline toast can pop up again.

#### What problem is this solving?

The offline toast should appear when there is no other toast been shown.

#### How should this be manually tested?

[Access the workspace](http://toast--storecomponents.myvtex.com) and open the dev tools and click the `Network > Offline` option (or turn off your device's network). Then click the buy button to see the offline toast be replaced but when the buy button toast goes away, the offline toast goes up again.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
