### PR TITLE
Passing navigationRoute and fetchPage false for the canonical replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.12.1] - 2019-04-12
 ### Changed
 - Pass `navigationRoute` to history's replace in `StoreWrapper`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Pass `navigationRoute` to history's replace in `StoreWrapper`.
 
 ## [2.12.0] - 2019-04-10
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -41,6 +41,10 @@ const systemToCanonical = ({ page, pages, route, history }) => {
 const replaceHistoryToCanonical = ({ route, history }, canonicalPath) => {
   const pathname = path(['location', 'pathname'], history)
   const search = path(['location', 'search'], history)
+  const navigationRoute = path(
+    ['location', 'state', 'navigationRoute'],
+    history
+  )
 
   if (!canonicalPath || !pathname) {
     return
@@ -50,6 +54,8 @@ const replaceHistoryToCanonical = ({ route, history }, canonicalPath) => {
 
   if (decodedCanonicalPath !== pathname) {
     history.replace(`${canonicalPath}${search}`, {
+      fetchPage: false,
+      navigationRoute,
       renderRouting: true,
       route,
     })


### PR DESCRIPTION
Related PR, should be released after this one: [render-runtime](https://github.com/vtex-apps/render-runtime/pull/272)

Test [here](https://cafedovento--storecomponents.myvtex.com/) using our search, changing the sort option, and going back. It didn't work before.

**Why is this necessary**
For some routes, we have two paths, one being the main one and the other being a canonical path, declared like this on _routes.json_

```javascript
"store.search#brand": {
    "path": "/:brand/b",
    "canonical": "/:brand"
  }
```

This is part of the mecanism to make possible the user navigate to `/shoes`, _shoes_ being a category, and get that page relative to a _category_. When someone accesses `/shoes/c` for the first time we save that registry and `/shoes` is now a category path, and we redirect now a user that tries to navigate to `/shoes/c`.

But that means that we would have to have two navigations for a simple transition, and with every navigation we fetch some heavy data on `pages-graphql`. To avoid fetching the same data again unnecessarily, there was the `if (!state.navigationRoute)` in the `RenderProvider`'s `onPageChanged` that would do that. But, in some cases when going back in the search-result flow (like trying to go to the last applied filter), the lack of the `navigationRoute` caused by that _canonical replace_ would make the `onPageChanged` return and not really change anything on page.

A couple of weeks ago I've added a `fetchPage` option to avoid fetching navigation data on some occasions. What I've done here is use that option instead of not passing `navigationRoute`