### PR TITLE
Add "defineMessages" for both editor and normal messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `defineMessages` for both editor and normal messages.
 
 ## [2.12.2] - 2019-04-12
 ### Changed

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,5 +1,0 @@
-{
-  "editor.product-search.title": "editor.product-search.title",
-  "editor.product-search.maxItemsPerPage": "editor.product-search.maxItemsPerPage",
-  "store.network-status.offline": "store.network-status.offline"
-}

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1,5 +1,0 @@
-{
-  "editor.product-search.title": "Product search context",
-  "editor.product-search.maxItemsPerPage": "Maximum number of items per page",
-  "store.network-status.offline": "No internet connection."
-}

--- a/messages/es-AR.json
+++ b/messages/es-AR.json
@@ -1,5 +1,0 @@
-{
-  "editor.product-search.title": "Contexto de búsqueda de productos",
-  "editor.product-search.maxItemsPerPage": "Número máximo de elementos por página",
-  "store.network-status.offline": "Sin conexión a internet."
-}

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,0 +1,5 @@
+{
+  "admin/editor.product-search.title": "Contexto de búsqueda de productos",
+  "admin/editor.product-search.maxItemsPerPage": "Número máximo de elementos por página",
+  "store/store.network-status.offline": "Sin conexión a internet."
+}

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1,5 +1,0 @@
-{
-  "editor.product-search.title": "Contexto de busca de produtos",
-  "editor.product-search.maxItemsPerPage": "Número máximo de elementos por página",
-  "store.network-status.offline": "Sem conexão à internet."
-}

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,0 +1,5 @@
+{
+  "admin/editor.product-search.title": "Contexto de busca de produtos",
+  "admin/editor.product-search.maxItemsPerPage": "Número máximo de elementos por página",
+  "store/store.network-status.offline": "Sem conexão à internet."
+}

--- a/react/SearchContext.js
+++ b/react/SearchContext.js
@@ -12,12 +12,12 @@ const DEFAULT_MAX_ITEMS_PER_PAGE = 10
 
 const editorMessages = defineMessages({
   ProductSearchMaxItemsPerPage: {
-    id: 'editor.product-search.maxItemsPerPage',
-    defaultMessage: ''
+    id: 'admin/editor.product-search.maxItemsPerPage',
+    defaultMessage: 'Maximum number of items per page'
   },
   ProductSearchTitle: {
-    id: 'editor.product-search.title',
-    defaultMessage: ''
+    id: 'admin/editor.product-search.title',
+    defaultMessage: 'Product search context'
   },
 })
 

--- a/react/SearchContext.js
+++ b/react/SearchContext.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Query } from 'react-apollo'
+import { defineMessages } from 'react-intl'
 import { withRuntimeContext } from 'vtex.render-runtime'
 
 import {search} from 'vtex.store-resources/Queries'
@@ -8,6 +9,17 @@ import { createInitialMap, SORT_OPTIONS } from './utils/search'
 
 const DEFAULT_PAGE = 1
 const DEFAULT_MAX_ITEMS_PER_PAGE = 10
+
+const editorMessages = defineMessages({
+  ProductSearchMaxItemsPerPage: {
+    id: 'editor.product-search.maxItemsPerPage',
+    defaultMessage: ''
+  },
+  ProductSearchTitle: {
+    id: 'editor.product-search.title',
+    defaultMessage: ''
+  },
+})
 
 class SearchContext extends Component {
   static propTypes = {
@@ -49,11 +61,11 @@ class SearchContext extends Component {
   }
 
   static schema = {
-    title: 'editor.product-search.title',
+    title: editorMessages.ProductSearchTitle.id,
     type: 'object',
     properties: {
       maxItemsPerPage: {
-        title: 'editor.product-search.maxItemsPerPage',
+        title: editorMessages.ProductSearchMaxItemsPerPage.id,
         type: 'number',
       },
       queryField: {

--- a/react/components/NetworkStatusToast.js
+++ b/react/components/NetworkStatusToast.js
@@ -1,13 +1,20 @@
 import PropTypes from 'prop-types'
 import { path, pathOr } from 'ramda'
 import { useContext, useEffect, useState } from 'react'
-import { injectIntl, intlShape } from 'react-intl'
+import { defineMessages, injectIntl, intlShape } from 'react-intl'
 import { ToastContext } from 'vtex.styleguide'
+
+const messages = defineMessages({
+  StoreNetworkStatusOffline: {
+    id: 'store.network-status.offline',
+    defaultMessage: ''
+  },
+})
 
 function NetworkStatusToast(props) {
   const toastConfig = {
     message: props.intl.formatMessage({
-      id: 'store.network-status.offline',
+      id: messages.StoreNetworkStatusOffline.id,
     }),
     dismissable: false,
     duration: Infinity,

--- a/react/components/NetworkStatusToast.js
+++ b/react/components/NetworkStatusToast.js
@@ -6,8 +6,8 @@ import { ToastContext } from 'vtex.styleguide'
 
 const messages = defineMessages({
   StoreNetworkStatusOffline: {
-    id: 'store.network-status.offline',
-    defaultMessage: ''
+    id: 'store/store.network-status.offline',
+    defaultMessage: 'No internet connection.'
   },
 })
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add "defineMessages" for editor messages and normal messages too as a way of having a map of which messages each component has.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
