### PR TITLE
Allow Title Block in Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `title` as allowed to store block.
 
 ## [2.12.2] - 2019-04-12
 ### Changed

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -21,7 +21,8 @@
       "info-card",
       "newsletter",
       "rich-text",
-      "flex-layout"
+      "flex-layout",
+      "title"
     ],
     "preview": {
       "type": "block"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow the `title` component from `vtex.store-components` in any page of the store.

#### What problem is this solving?

The `title` component from `vtex.store-components` should be able to be used in any page of the store. You can display an HTML heading of any level using this component.

#### How should this be manually tested?
1. Add a block and a definition to the `blocks.json` of `vtex.store-theme`.
2. Change the props (`alignment`, `content`, `level`) to see the effect.

#### Screenshots or example usage
![title](https://user-images.githubusercontent.com/42151054/56271267-b9261900-6115-11e9-80d3-69f8efccfe4e.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
