### PR TITLE
Allow CategoriesHighlights in Homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `categories-highlights` as allowed to `store.home` block.
 
 ## [2.12.2] - 2019-04-12
 ### Changed

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -35,7 +35,8 @@
       "header.full"
     ],
     "allowed": [
-      "search-result"
+      "search-result",
+      "categories-highlights"
     ]
   },
   "store.product": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow `CategoriesHighlights` from `vtex.store-components` in the homepage of the store.

#### What problem is this solving?

We want to show featured categories of each department in the homepage of our store.

#### How should this be manually tested?
Configure the layout settings and the content using the `blocks.json` of `vtex.store-theme` to see the effect in the homepage.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
