### PR TITLE
Fix search title and meta description not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.12.4] - 2019-04-25
 ### Fixed
 - Search title and meta description not reflecting API result.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Search title and meta description not reflecting API result.
 
 ## [2.12.3] - 2019-04-16
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/SearchWrapper.js
+++ b/react/SearchWrapper.js
@@ -75,38 +75,36 @@ class SearchWrapper extends Component {
     const {
       params,
       searchQuery: {
-        data: search,
-        data: {
-          titleTag,
-          metaTagDescription,
-        } = {},
+        data: { search, search: { titleTag, metaTagDescription } = {} } = {},
         loading,
       },
-      runtime: {
-        getSettings,
-      },
+      runtime: { getSettings },
     } = this.props
     const settings = getSettings(APP_LOCATOR) || {}
-    const {
-      titleTag: storeTitle,
-      metaTagKeywords,
-    } = settings
+    const { titleTag: storeTitle, metaTagKeywords } = settings
 
     return (
       <DataLayerApolloWrapper
         getData={() => this.getData(search)}
         loading={loading}
       >
-        <Helmet>
-          {titleTag
-            ? <title>{titleTag}</title>
-            : params.term && <title>{`${capitalize(params.term)} - ${storeTitle}`}</title>}
-          {params.term &&
-            <meta name="keywords" content={`${params.term}, ${metaTagKeywords}`} />}
-          {metaTagDescription && (
-            <meta name="description" content={metaTagDescription} />
-          )}
-        </Helmet>
+        <Helmet
+          title={
+            titleTag
+              ? titleTag
+              : params.term && `${capitalize(params.term)} - ${storeTitle}`
+          }
+          meta={[
+            params.term && {
+              name: 'keywords',
+              content: `${params.term}, ${metaTagKeywords}`,
+            },
+            metaTagDescription && {
+              name: 'description',
+              content: metaTagDescription,
+            },
+          ].filter(Boolean)}
+        />
         {React.cloneElement(this.props.children, this.props)}
       </DataLayerApolloWrapper>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Get the title tag and meta tag description values from the search property *inside* the data.

#### What problem is this solving?
These values weren't being retrieved from the correct object, thus making the title and meta description not reflecting the current page values.

#### How should this be manually tested?
[Workspace](https://lucas2--storecomponents.myvtex.com/decoration/tvs).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
