### PR TITLE
Append the hash to the returnUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.14.2] - 2019-04-26
 ### Fixed
 - Append the URL hash to the `returnUrl` param to login.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Append the URL hash to the `returnUrl` param to login.
 
 ## [2.14.1] - 2019-04-25
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/ProfileChallenge.js
+++ b/react/ProfileChallenge.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 
 import { useRuntime, Loading } from 'vtex.render-runtime'
@@ -6,9 +6,22 @@ import { useRuntime, Loading } from 'vtex.render-runtime'
 const LOGIN_PATH = '/login'
 const API_SESSION_URL = '/api/sessions?items=*'
 
+function useSafeState(initialState) {
+  const [state, setState] = useState(initialState)
+
+  const mountedRef = useRef(false)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => (mountedRef.current = false)
+  }, [])
+  const safeSetState = (...args) => mountedRef.current && setState(...args)
+
+  return [state, safeSetState]
+}
+
 const ProfileChallenge = ({ children, page }) => {
-  const [loading, setLoading] = useState(true)
-  const [loggedIn, setLoggedIn] = useState(false)
+  const [loading, setLoading] = useSafeState(true)
+  const [loggedIn, setLoggedIn] = useSafeState(false)
   const { navigate } = useRuntime()
 
   useEffect(

--- a/react/ProfileChallenge.js
+++ b/react/ProfileChallenge.js
@@ -13,7 +13,6 @@ const ProfileChallenge = ({ children, page }) => {
 
   useEffect(
     () => {
-      if (!loggedIn && loading) return
       fetch(API_SESSION_URL, { credentials: 'same-origin' })
         .then(response => response.json())
         .then(response => {
@@ -34,7 +33,7 @@ const ProfileChallenge = ({ children, page }) => {
           redirectToLogin()
         })
     },
-    [loggedIn, loading]
+    [page]
   )
 
   const getLocation = () => {

--- a/react/ProfileChallenge.js
+++ b/react/ProfileChallenge.js
@@ -13,6 +13,7 @@ const ProfileChallenge = ({ children, page }) => {
 
   useEffect(
     () => {
+      if (!loggedIn && loading) return
       fetch(API_SESSION_URL, { credentials: 'same-origin' })
         .then(response => response.json())
         .then(response => {
@@ -33,7 +34,7 @@ const ProfileChallenge = ({ children, page }) => {
           redirectToLogin()
         })
     },
-    [loggedIn]
+    [loggedIn, loading]
   )
 
   const getLocation = () => {
@@ -70,12 +71,7 @@ const ProfileChallenge = ({ children, page }) => {
 
 ProfileChallenge.propTypes = {
   page: PropTypes.string,
-  pages: PropTypes.object,
-  runtime: PropTypes.shape({
-    navigate: PropTypes.func,
-  }),
   children: PropTypes.node,
-  loader: PropTypes.element,
 }
 
 export default ProfileChallenge


### PR DESCRIPTION
Test it on [ituacu](https://ituacu--storecomponents.myvtex.com/account#/profile)

Related [story](https://app.clubhouse.io/vtex-dev/story/3600/follow-the-returnurl-param)

Before this, if you navigate to `/account#/orders` and wasn't logged in, the redirect would occur with the `returnUrl=%2Faccount`, losing the hash, that identifies a specific page on `my-account`. 