### PR TITLE
Use only category and full text to facets query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Split query and map used in facets from search.
 
 ## [2.14.2] - 2019-04-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.15.0] - 2019-04-26
 ### Changed
 - Split query and map used in facets from search.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.14.2",
+  "version": "2.15.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/SearchContext.js
+++ b/react/SearchContext.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { path } from 'ramda'
+import { path, zip } from 'ramda'
 import React from 'react'
 import { Query } from 'react-apollo'
 import { useRuntime } from 'vtex.render-runtime'
@@ -62,10 +62,30 @@ const SearchContext = ({
     withFacets: includeFacets(mapField, queryField),
   }
 
+  const queryVariables = queryField ? customSearch : defaultSearch
+
+  const [facetQuery, facetMap] = zip(
+    queryVariables.query.split('/'),
+    queryVariables.map.split(',')
+  )
+    .filter(([_, map]) => map === 'c' || map === 'ft')
+    .reduce(
+      ([queryAcc, mapAcc], [query, map]) => [
+        [...queryAcc, query],
+        [...mapAcc, map],
+      ],
+      // first empty array is for query and the second
+      // for map
+      [[], []]
+    )
+
+  queryVariables.facetQuery = facetQuery.join('/')
+  queryVariables.facetMap = facetMap.join(',')
+
   return (
     <Query
       query={productSearch}
-      variables={queryField ? customSearch : defaultSearch}
+      variables={queryVariables}
       notifyOnNetworkStatusChange
       partialRefetch
     >

--- a/react/SearchContext.js
+++ b/react/SearchContext.js
@@ -64,19 +64,17 @@ const SearchContext = ({
 
   const queryVariables = queryField ? customSearch : defaultSearch
 
-  const [facetQuery, facetMap] = zip(
+  const { map: facetMap, query: facetQuery } = zip(
     queryVariables.query.split('/'),
     queryVariables.map.split(',')
   )
     .filter(([_, map]) => map === 'c' || map === 'ft')
     .reduce(
-      ([queryAcc, mapAcc], [query, map]) => [
-        [...queryAcc, query],
-        [...mapAcc, map],
-      ],
-      // first empty array is for query and the second
-      // for map
-      [[], []]
+      ({ query: queryArr, map: mapArr }, [query, map]) => ({
+        query: [...queryArr, query],
+        map: [...mapArr, map],
+      }),
+      { map: [], query: [] }
     )
 
   queryVariables.facetQuery = facetQuery.join('/')


### PR DESCRIPTION
#### What is the purpose of this pull request?
To pass only the category (map `c`) and full text (map `ft`) to the facets query.

#### What problem is this solving?
Stable filters feature, see vtex-apps/search-result#150.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/clothing/shirts?map=c%2Cc).

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
