### PR TITLE
adding refetch parameter to ProductContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `refetch` parameter to `ProductContext`
 
 ## [2.15.1] - 2019-04-29
 ### Fixed

--- a/react/ProductContext.js
+++ b/react/ProductContext.js
@@ -89,6 +89,7 @@ class ProductContext extends Component {
       params,
       params: { slug },
       client,
+      catalog : { refetch },
       ...props
     } = this.props
 
@@ -106,6 +107,7 @@ class ProductContext extends Component {
     const productQuery = {
       loading,
       product,
+      refetch
     }
 
     // why do we still have this?


### PR DESCRIPTION
#### What is the purpose of this pull request?

We added the refetch parameter in ProductContext.js for then use in the ProductDetail component. 

#### What problem is this solving?

With this we can update the product information when some change in the catalog happens.

#### How should this be manually tested?

[Workspace](https://vtexexito--prueba1.myvtex.com/aguardiente/p)
NOTE: it is a exito subaccount and the workspace is free the custom components.

The `ProductQuery` prop in the `ProductDetails` component should have the method `refetch`. When this method is executed should update the product information.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.