### PR TITLE
Fix/no image crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent infinite error loop if image is undefined.
 
 ## [2.15.0] - 2019-04-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.15.1] - 2019-04-29
 ### Fixed
 - Prevent infinite error loop if image is undefined.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/components/StructuredData.js
+++ b/react/components/StructuredData.js
@@ -151,7 +151,7 @@ const parseToJsonLD = (product, query, currency, locale) => {
     '@type': 'Product',
     name: name,
     brand: brand,
-    image: image.imageUrl,
+    image: image && image.imageUrl,
     description: description,
     mpn: product.productId,
     sku: skuId,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Prevent crash on product page if the product has no image.

After:
https://lbebber--invictastores.myvtex.com/invicta-marvel-limited-edition-captain-america-mens-quartz-43-5mm-stainless-steel-case-red--blue-dial---model-27024/p

Before (warning, might crash your browser):
https://invictastores.myvtex.com/invicta-marvel-limited-edition-captain-america-mens-quartz-43-5mm-stainless-steel-case-red--blue-dial---model-27024/p

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
