### PR TITLE
decode uri when getting page title on searchwrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.16.1] - 2019-04-30
 ### Fixed
 - `SearchWrapper`: Decode URI when getting page title.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `SearchWrapper`: Decode URI when getting page title.
 
 ## [2.16.0] - 2019-04-29
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/SearchWrapper.js
+++ b/react/SearchWrapper.js
@@ -92,7 +92,7 @@ class SearchWrapper extends Component {
           title={
             titleTag
               ? titleTag
-              : params.term && `${capitalize(params.term)} - ${storeTitle}`
+              : params.term && `${capitalize(decodeURI(params.term))} - ${storeTitle}`
           }
           meta={[
             params.term && {


### PR DESCRIPTION
fix: https://app.clubhouse.io/vtex-dev/story/10295/product-name-is-encoded-on-search-title

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
