### PR TITLE
NetworkStatusToast is now dismissable on mobile devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `NetworkStatusToast` need to be dismissable on mobile devices.
 
 ## [2.22.3] - 2019-05-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.22.4] - 2019-05-15
 ### Fixed
 - `NetworkStatusToast` need to be dismissable on mobile devices.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.22.3",
+  "version": "2.22.4",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says...

#### What problem is this solving?

On mobile devices, the toast was overlaying the buy button. Now it can be dismissed.

#### How should this be manually tested?

[Access the workspace](http://offline--storecomponents.myvtex.com)

#### Screenshots or example usage

![Offline Toast](https://user-images.githubusercontent.com/15948386/57718085-eef5e900-7652-11e9-8534-df96de813f99.gif)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
