### PR TITLE
Add 'map' to store routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- New `map` field on routes to better support legacy URLs.
 
 ## [2.22.2] - 2019-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.22.3] - 2019-05-15
 ### Added
 
 - New `map` field on routes to better support legacy URLs.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/store/routes.json
+++ b/store/routes.json
@@ -17,17 +17,21 @@
   },
   "store.search#brand": {
     "path": "/:brand/b",
-    "canonical": "/:brand"
+    "canonical": "/:brand",
+    "map": ["b"]
   },
   "store.search#department": {
     "path": "/:department/d",
-    "canonical": "/:department"
+    "canonical": "/:department",
+    "map": ["c"]
   },
   "store.search#category": {
-    "path": "/:department/:category"
+    "path": "/:department/:category",
+    "map": ["c", "c"]
   },
   "store.search#subcategory": {
-    "path": "/:department/:category/:subcategory"
+    "path": "/:department/:category/:subcategory",
+    "map": ["c", "c", "c"]
   },
   "store.search#subcategory-terms": {
     "path": "/:department/:category/:subcategory/*terms"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a new field to store routes: `map`

#### What problem is this solving?
We need to support legacy routes using `map` query string. For instance `/smartphones/Blanco?map=c,specification_filter39` should be a filtered *department* page but is identified as a *category* page because it matches the path `/:department/:category`.

The new `map` field will be available to do a proper route matching in pages-graphql and render-runtime.

Depends on: https://github.com/vtex/builder-hub/pull/549
#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
