### PR TITLE
Remove canonical discovery and history replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.22.5] - 2019-05-16
 ### Changed
 - Remove canonical discovery and history replacement code.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove canonical discovery and history replacement code.
 
 ## [2.22.4] - 2019-05-15
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.22.4",
+  "version": "2.22.5",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -1,4 +1,3 @@
-import { path } from 'ramda'
 import React, { Component, Fragment } from 'react'
 import {
   canUseDOM,
@@ -14,7 +13,6 @@ import PixelManager from 'vtex.pixel-manager/PixelManager'
 import { ToastProvider } from 'vtex.styleguide'
 import { PWAProvider } from 'vtex.store-resources/PWAContext'
 
-import canonicalPathFromParams from './utils/canonical'
 import PageViewPixel from './components/PageViewPixel'
 import OrderFormProvider from './components/OrderFormProvider'
 import NetworkStatusToast from './components/NetworkStatusToast'
@@ -26,39 +24,12 @@ const CONTENT_TYPE = 'text/html; charset=utf-8'
 const META_ROBOTS = 'index, follow'
 const MOBILE_SCALING = 'width=device-width, initial-scale=1'
 
-const systemToCanonical = ({ page, pages, route, history }) => {
-  const { params } = route
-  const canonicalRouteTemplate = pages[page].canonical
-  const canonicalPath = canonicalPathFromParams(canonicalRouteTemplate, params)
+const systemToCanonical = ({ canonicalPath }) => {
   const canonicalHost =
     window.__hostname__ || (window.location && window.location.hostname)
   return {
     canonicalPath,
     canonicalHost,
-  }
-}
-
-const replaceHistoryToCanonical = ({ route, history }, canonicalPath) => {
-  const pathname = path(['location', 'pathname'], history)
-  const search = path(['location', 'search'], history)
-  const navigationRoute = path(
-    ['location', 'state', 'navigationRoute'],
-    history
-  )
-
-  if (!canonicalPath || !pathname) {
-    return
-  }
-
-  const decodedCanonicalPath = decodeURIComponent(canonicalPath)
-
-  if (decodedCanonicalPath !== pathname) {
-    history.replace(`${canonicalPath}${search}`, {
-      fetchPage: false,
-      navigationRoute,
-      renderRouting: true,
-      route,
-    })
   }
 }
 
@@ -123,13 +94,7 @@ class StoreWrapper extends Component {
       data: { manifest, pwaSettings, iOSIcons, splashes, loading, error } = {},
     } = this.props
     const hasManifest = !loading && manifest && !error
-    const { canonicalHost, canonicalPath } = systemToCanonical({
-      pages,
-      page,
-      route,
-      history,
-    })
-    replaceHistoryToCanonical({ route, history }, canonicalPath)
+    const { canonicalHost, canonicalPath } = systemToCanonical(route)
 
     return (
       <Fragment>

--- a/react/package.json
+++ b/react/package.json
@@ -8,8 +8,7 @@
     "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.5.10",
     "ramda": "^0.26.1",
-    "react-slick": "^0.16.0",
-    "route-parser": "^0.0.5"
+    "react-slick": "^0.16.0"
   },
   "devDependencies": {
     "apollo-client-preset": "^1.0.8",

--- a/react/utils/canonical.js
+++ b/react/utils/canonical.js
@@ -1,9 +1,0 @@
-import { isEmpty } from 'ramda'
-import RouteParser from 'route-parser'
-
-const canonicalPathFromParams = (canonicalRouteTemplate, params) =>
-  !isEmpty(params) && canonicalRouteTemplate
-    ? new RouteParser(canonicalRouteTemplate).reverse(params)
-    : null
-
-export default canonicalPathFromParams

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4695,11 +4695,6 @@ rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.1.3"
 
-route-parser@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/route-parser/-/route-parser-0.0.5.tgz#7d1d09d335e49094031ea16991a4a79b01bbe1f4"
-  integrity sha1-fR0J0zXkkJQDHqFpkaSnmwG74fQ=
-
 rst-selector-parser@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove canonical discovery and  history replacement code from `vtex.store`

#### What problem is this solving?
Canonical paths will now be handled by `render-runtime` itself. This will make everything simpler as we won't need to do a double history push/replace.

For instance, `render-runtime` navigates to `/department/d` then `vtex.store` code changes it to `/department`.  Now `render-runtime` will set the path directly to `/department`, making our history manipulation sane 🙏 

Depends on https://github.com/vtex-apps/render-runtime/pull/291
#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
