### PR TITLE
Bring back CustomWrapper component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Fix missing CustomWrapper component error.
 
 ## [2.26.0] - 2019-05-27
 

--- a/react/CustomWrapper.js
+++ b/react/CustomWrapper.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types'
+
+const CustomWrapper = ({ children }) => {
+  return children
+}
+
+CustomWrapper.propTypes = {
+  children: PropTypes.node,
+}
+
+export default CustomWrapper


### PR DESCRIPTION
#### What is the purpose of this pull request?
Bring back CustomWrapper component

#### What problem is this solving?
Themes made when CustomWrapper were a thing are throwing errors because the component is missing. Ex: Go to https://home--alssports.myvtex.com, then navigate to https://home--alssports.myvtex.com/mens using the menu link.

#### How should this be manually tested?
Linking this branch in alssports/home fix the error

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
