### PR TITLE
Fix multiple manifests added to the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.28.1] - 2019-06-05
 ### Fixed
 - Multiple manifest being added to the page `head`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Multiple manifest being added to the page `head`.
 
 ## [2.28.0] - 2019-06-04
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -131,7 +131,7 @@ class StoreWrapper extends Component {
                     link={[
                       {
                         rel: 'manifest',
-                        href: `/pwa/manifest.json?v=${Date.now()}`,
+                        href: '/pwa/manifest.json',
                       },
                       ...(iOSIcons
                         ? iOSIcons.map(icon => ({


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the `v` query with `Date.now()` from the manifest url.

#### What problem is this solving?
This fixes multiple manifests being added to the page `head`, because the query render prop was being executed several times, and each time it rendered the `Helmet` added a new manifest to the page, because of the different query strings.

#### How should this be manually tested?
[workspace](https://lucas2--storecomponents.myvtex.com/?__debugSW).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
