### PR TITLE
Add rootPath on pwa routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.29.1] - 2019-06-10
+
 ## [2.29.1-beta] - 2019-06-10
 ### Fixed
 - Root path not prepended to PWA-related routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Root path not prepended to PWA-related routes.
 
 ## [2.29.0] - 2019-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.29.1-beta] - 2019-06-10
 ### Fixed
 - Root path not prepended to PWA-related routes.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.29.1-beta",
+  "version": "2.29.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.29.0",
+  "version": "2.29.1-beta",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -87,6 +87,7 @@ class StoreWrapper extends Component {
         route,
         route: { metaTags, title: pageTitle },
         getSettings,
+        rootPath = '',
       },
     } = this.props
     const settings = getSettings(APP_LOCATOR) || {}
@@ -122,18 +123,18 @@ class StoreWrapper extends Component {
                     link={[
                       {
                         rel: 'manifest',
-                        href: '/pwa/manifest.json',
+                        href: `${rootPath}/pwa/manifest.json`,
                       },
                       ...(iOSIcons
                         ? iOSIcons.map(icon => ({
                             rel: 'apple-touch-icon',
                             sizes: icon.sizes,
-                            href: icon.src,
+                            href: `${rootPath}${icon.src}`,
                           }))
                         : []),
                       ...(splashes
                         ? splashes.map(splash => ({
-                            href: splash.src,
+                            href: `${rootPath}${splash.src}`,
                             sizes: splash.sizes,
                             rel: 'apple-touch-startup-image',
                           }))
@@ -162,7 +163,7 @@ class StoreWrapper extends Component {
           script={[
             {
               type: 'text/javascript',
-              src: `/pwa/workers/register.js${route.path.match(
+              src: `${rootPath}/pwa/workers/register.js${route.path.match(
                 /\?.*/
               ) || ''}`,
               defer: true,

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -105,6 +105,8 @@ class StoreWrapper extends Component {
       joinKeywords(metaTags && metaTags.keywords) || metaTagKeywords
     const title = pageTitle || titleTag
 
+    const [queryMatch] = route.path.match(/\?.*/) || '?'
+
     return (
       <Fragment>
         <Query query={pwaDataQuery} ssr={false}>
@@ -163,9 +165,9 @@ class StoreWrapper extends Component {
           script={[
             {
               type: 'text/javascript',
-              src: `${rootPath}/pwa/workers/register.js${route.path.match(
-                /\?.*/
-              ) || ''}`,
+              src: `${rootPath}/pwa/workers/register.js${queryMatch}&scope=${encodeURIComponent(
+                rootPath
+              )}`,
               defer: true,
             },
           ]}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Prepend the `rootPath` on the PWA-related routes.

#### What problem is this solving?
When the store is configured with a root path (e.g. `/ar`), the pwa routes inserted into the page were directed to `/pwa/*path`, but in fact they should be `/ar/pwa/*path`.

#### How should this be manually tested?
[workspace](https://lucas2--storecomponents.myvtex.com/)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
