### PR TITLE
Show the heart icon of wish list in product details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.30.1] - 2019-06-12
 ### Fixed
 - Show the heart icon of wish list in product details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Show the heart icon of wish list in product details.
 
 ## [2.30.0] - 2019-06-10
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -40,6 +40,7 @@
       "header.full"
     ],
     "allowed": [
+      "product-addon-wrapper",
       "product-details",
       "product-kit",
       "product-reviews",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -40,7 +40,7 @@
       "header.full"
     ],
     "allowed": [
-      "product-addon-wrapper",
+      "product-add-to-list-button",
       "product-details",
       "product-kit",
       "product-reviews",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Show the heart icon of wish list in product details.

#### What problem is this solving?

In product details screen doesn't show the heart icon to add product in wish list.

### How should this be manually tested?

[workspace](https://thaynan--storecomponents.myvtex.com/)

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
