### PR TITLE
Add robots meta tag with "noindex,follow" when it's a search result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.30.2] - 2019-06-12
+
 ### Fixed
 
 - Add robots meta tag with "noindex,follow" when it's a search result.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add robots meta tag with "noindex,follow" when it's a search result.
+
 ## [2.30.1] - 2019-06-12
 ### Fixed
 - Show the heart icon of wish list in product details.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.30.1",
+  "version": "2.30.2",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/SearchWrapper.js
+++ b/react/SearchWrapper.js
@@ -85,6 +85,10 @@ const SearchWrapper = props => {
             name: 'keywords',
             content: `${params.term}, ${metaTagKeywords}`,
           },
+          params.term && {
+            name: 'robots',
+            content: 'noindex,follow',
+          },
           metaTagDescription && {
             name: 'description',
             content: metaTagDescription,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix SEO issues.

#### What problem is this solving?

Google is indexing search results when it shouldn't.

#### How should this be manually tested?

Search for something in the search bar, verify if it has the meta tag robots with the value "noindex,follow". Categories and department pages should have "index, follow".

https://breno--storecomponents.myvtexdev.com/top/s?map=ft

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/59357274-e996c780-8d00-11e9-90af-4c19e765901d.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
