### PR TITLE
Add Open Graph to Product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.32.0] - 2019-06-17
+
 ### Added
 
 - Open Graph protocol to product page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Open Graph protocol to product page.
+
 ## [2.31.1] - 2019-06-14
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -42,7 +42,8 @@
     "vtex.breadcrumb": "1.x",
     "vtex.product-availability": "0.x",
     "vtex.product-quantity": "1.x",
-    "vtex.shop-review-interfaces": "0.x"
+    "vtex.shop-review-interfaces": "0.x",
+    "vtex.open-graph": "1.x"
   },
   "settingsSchema": {
     "title": "VTEX Store",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.31.1",
+  "version": "2.32.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/react/ProductWrapper.js
+++ b/react/ProductWrapper.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useMemo, useState } from 'react'
 import { last, head, path } from 'ramda'
 import { Helmet, useRuntime } from 'vtex.render-runtime'
+import { ProductOpenGraph } from 'vtex.open-graph'
 import { ProductContext as ProductContextApp } from 'vtex.product-context'
 
 import StructuredData from './components/StructuredData'
@@ -135,6 +136,7 @@ const ProductWrapper = ({
         ].filter(Boolean)}
       />
       <ProductContextApp.Provider value={value}>
+        {product && <ProductOpenGraph />}
         {product && <StructuredData product={product} query={query} />}
         {React.cloneElement(children, childrenProps)}
       </ProductContextApp.Provider>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add Open Graph to product page.

#### What problem is this solving?

With Open Graph social networks like: Facebook can add rich previews to product page link.

Also, some integrations like Facebook Pixel and Bluecore read those tags natively.

#### How should this be manually tested?

Open:
https://breno--storecomponents.myvtexdev.com/classic-shoes/p

Look for the Open Graph meta tags, like: `og:type`, `product:brand`, etc.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/59478697-9c197800-8e30-11e9-8a3f-f3a586af2a56.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
