### PR TITLE
Add Product properties on SearchQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+ - Product properties on SearchQuery
+
+
 ## [1.39.0] - 2019-05-23
 ### Added
 - Force `register.js` to be fetched when `StoreContextProvider` is rendered to allow service workers to be disabled properly.

--- a/react/queries/searchQuery.gql
+++ b/react/queries/searchQuery.gql
@@ -71,6 +71,10 @@ query search(
       linkText
       brand
       link
+      properties {
+        name
+        values
+      }
       items {
         itemId
         name


### PR DESCRIPTION
#### What is the purpose of this pull request?
 Add product properties to Search Results to Store v1 (Our client Naturitas it's right now on store v1)

#### What problem is this solving?

Our clients want display some product properties on Search Result,  and this is the only way.

#### How should this be manually tested?

1. Go to search results page and check all it's fine, and the SearchQuery Props have properties on array products.
2. APP its linked in this workspace: https://pmartin--naturitasit.myvtex.com/cosmetica-e-igiene/cura-del-corpo/esfoliante-per-il-corpo

#### Screenshots or example usage
<img width="1811" alt="Search-Query-ProductProperties" src="https://user-images.githubusercontent.com/16488733/60207417-24971000-9856-11e9-848f-20f87726653d.png">


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
