### PR TITLE
[WIP] Adds id to translatable routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Adds optional id to routes with translatable slugs
 
 ## [2.33.2] - 2019-06-26
 ### Fixed

--- a/store/routes.json
+++ b/store/routes.json
@@ -9,28 +9,28 @@
     "path": "/login"
   },
   "store.product": {
-    "path": "/:slug/p"
+    "path": "/:slug/p/*id"
   },
   "store.search": {
     "path": "/:term/s",
     "canonical": "/:term"
   },
   "store.search#brand": {
-    "path": "/:brand/b",
+    "path": "/:brand/b/*id",
     "canonical": "/:brand",
     "map": ["b"]
   },
   "store.search#department": {
-    "path": "/:department/d",
+    "path": "/:department/d/*id",
     "canonical": "/:department",
     "map": ["c"]
   },
   "store.search#category": {
-    "path": "/:department/:category",
+    "path": "/:department/:category/c/*id",
     "map": ["c", "c"]
   },
   "store.search#subcategory": {
-    "path": "/:department/:category/:subcategory",
+    "path": "/:department/:category/:subcategory/sc/*id",
     "map": ["c", "c", "c"]
   },
   "store.search#subcategory-terms": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR will enable us to move forward with the translatable slugs feature by adding optional ids to the routes 

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
