### PR TITLE
Add product-identifier to PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `product-identifier` as allowed in product page.
 
 ## [2.38.0] - 2019-07-03
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,7 @@
     "vtex.product-availability": "0.x",
     "vtex.product-quantity": "1.x",
     "vtex.shop-review-interfaces": "0.x",
+    "vtex.product-identifier": "0.x",
     "vtex.open-graph": "1.x"
   },
   "settingsSchema": {

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -61,7 +61,8 @@
       "availability-subscriber",
       "share",
       "product-highlights",
-      "product-availability"
+      "product-availability",
+      "product-identifier"
     ],
     "context": "ProductContext",
     "preview": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make it possible to do https://github.com/vtex-apps/store-theme/pull/153

#### What problem is this solving?

Allow to use a new block.

#### How should this be manually tested?

[Workspace](https://breno3--storecomponents.myvtex.com/long-sleeve-shirt/p)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/60531918-76b2b800-9cd2-11e9-9b89-879057648eb8.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.


~Depends on publish https://github.com/vtex-apps/product-identifier first.~ published