### PR TITLE
Require header.full as `before` block of every store page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Require `header.full` instead of `header` on every store page.
 
 ## [2.37.0] - 2019-07-02
 ### Added

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -3,7 +3,7 @@
     "allowConditions": true,
     "component": "*",
     "around": ["storeWrapper", "challenge"],
-    "before": ["header"],
+    "before": ["header.full"],
     "after": ["footer", "pixels"],
     "allowed": [
       "notification.bar",
@@ -25,7 +25,6 @@
   },
   "store.home": {
     "around": ["homeWrapper"],
-    "before": ["header.full"],
     "allowed": ["search-result"],
     "preview": {
       "type": "box",
@@ -72,7 +71,6 @@
   },
   "store.search": {
     "around": ["searchWrapper"],
-    "before": ["header.full"],
     "required": ["search-result"],
     "context": "SearchContext",
     "preview": {
@@ -81,7 +79,6 @@
     }
   },
   "store.account": {
-    "before": ["header.full"],
     "required": ["my-account"],
     "around": ["challenge.profile"],
     "preview": {
@@ -90,7 +87,6 @@
     }
   },
   "store.login": {
-    "before": ["header.full"],
     "required": ["login-content"],
     "preview": {
       "type": "spinner",
@@ -106,7 +102,6 @@
     }
   },
   "store.product-review-form": {
-    "before": ["header.full"],
     "allowed": ["product-review-form"],
     "preview": {
       "type": "spinner",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Require header.full as `before` block of every store page

#### What problem is this solving?
Custom pages are not required to have `header.full`, just `header`. So you can end up with different headers on theses pages if you don't explicitly use `header.full`. It can be confusing because they may look similar (depending on your blocks.json) but the treePath and therefore content will be different.

#### How should this be manually tested?
Link any theme with a custom page and browse the custom page. `__RUNTIME__.extensions[__RUNTIME__.page].before` will give you `[$before_header]`
Link this branch and then link the theme again (ctrl-c + `vtex link`), now you have:
`__RUNTIME__.extensions[__RUNTIME__.page].before` = `[$before_header.full]`

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
