### PR TITLE
Fix ProductContext props passed to children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- ProductContext props passed to children.
+### Removed
+- ProductContext stray props being passed down, `props` and `breacrumbProps`.
 
 ## [2.46.0] - 2019-07-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- ProductContext props passed to children.
 
 ## [2.46.0] - 2019-07-26
 ### Added

--- a/react/ProductContext.js
+++ b/react/ProductContext.js
@@ -105,8 +105,8 @@ const ProductContext = _props => {
       },
       slug,
       params,
-      breadcrumbsProps,
-      props,
+      ...breadcrumbsProps,
+      ...props,
     }),
     [props, breadcrumbsProps, loading, product, refetch, slug, params]
   )

--- a/react/ProductContext.js
+++ b/react/ProductContext.js
@@ -76,20 +76,6 @@ const ProductContext = _props => {
     propsProduct ||
     (productPreview && productPreview.items ? productPreview : null)
 
-  /**
-   * The breadcrumb component is being used in multiple pages,
-   * therefore we need to adapt the data to its needs instead of
-   * making the component do the changes itself.
-   **/
-  const breadcrumbsProps = useMemo(
-    () => ({
-      term: slug,
-      categories: product ? product.categories : null,
-      categoryTree: product ? product.categoryTree : null,
-    }),
-    [product, slug]
-  )
-
   const childrenProps = useMemo(
     () => ({
       productQuery: {
@@ -105,10 +91,8 @@ const ProductContext = _props => {
       },
       slug,
       params,
-      ...breadcrumbsProps,
-      ...props,
     }),
-    [props, breadcrumbsProps, loading, product, refetch, slug, params]
+    [loading, product, refetch, slug, params]
   )
 
   return React.cloneElement(props.children, childrenProps)


### PR DESCRIPTION
#### What is the purpose of this pull request?

~Fix the props passed down from ProductContext.~
Remove stray props passed down from ProductContext.

This also fixes the usage of the interface `sandbox` in the product page, since that interface uses a `safe-json-stringify`, when this lib tried to stringify the props I think it was falling into a cycle making the browser tab to stop (ouch).

#### What problem is this solving?

I changed from `Object.assign` call to object spread the wrong way (I use to err on that a lot)

https://github.com/vtex-apps/store/commit/6f7fa240a4c18522c1cc0a386493c7a37ff3ec7d#diff-0aa7635b08024e9103931440d4c59db7R106

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/classic-shoes/p

#### Screenshots or example usage

**Props Before**
Notice that there are `props` and `breadcrumbProps` there.
![image](https://user-images.githubusercontent.com/284515/60692812-2b550100-9eae-11e9-8601-196306a41af4.png)

**Props After**
Removed props `props` and `breacrumbProps`.
![image](https://user-images.githubusercontent.com/284515/60728671-4576f980-9f17-11e9-9ac2-f62ed5c7b24a.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
