### PR TITLE
adds /:slug/p as product canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `/:slug/p` as product canonical page
 
 ## [2.39.0] - 2019-07-03
 ### Added

--- a/store/routes.json
+++ b/store/routes.json
@@ -9,7 +9,8 @@
     "path": "/login"
   },
   "store.product": {
-    "path": "/:slug/p(/:id)"
+    "path": "/:slug/p(/:id)",
+    "canonical": "/:slug/p"
   },
   "store.search": {
     "path": "/:term/s",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds /:slug/p as product canonical. This PR makes possible to have internal product urls without the user noticing in the url history

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
