### PR TITLE
Allow search-result to store.custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow `search-result` to `store.custom`.
 
 ## [2.41.0] - 2019-07-10
 ### Added

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -136,5 +136,7 @@
   "promo-bar": {
     "component": "*"
   },
-  "store.custom": {}
+  "store.custom": {
+    "allowed": ["search-result"]
+  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make it possible to add a search-result in store.custom.

#### What problem is this solving?

Make it possible to create this page:
https://www.eriksbikeshop.com/eriks-bicycle-buying-guide.aspx

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/about-us

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/61077829-93976b80-a3f5-11e9-8cdb-a0e2d86b6a6c.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
