### PR TITLE
Stop decoding titleTag

### DIFF
--- a/react/SearchWrapper.js
+++ b/react/SearchWrapper.js
@@ -25,7 +25,7 @@ const getPageEventName = (products, params) => {
 
 const getTitleTag = (titleTag, storeTitle, term) => {
   return titleTag
-    ? `${capitalize(decodeURI(titleTag))} - ${storeTitle}`
+    ? `${titleTag} - ${storeTitle}`
     : term
     ? `${capitalize(decodeURI(term))} - ${storeTitle}`
     : `${storeTitle}`


### PR DESCRIPTION
#### What is the purpose of this pull request?
Stop decoding titleTag

#### What problem is this solving?
`titleTag` does not need any decoding. The text is already the way it should be. When calling `decodeURI` we are throwing an error if the text contains something like `50% OFF`.

```
> decodeURI('50% OFF')
VM162:1 Uncaught URIError: URI malformed
    at decodeURI (<anonymous>)
    at <anonymous>:1:1
```

It is breaking the page.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
