### PR TITLE
Add various blog pages in conjunction with vtex.blog-interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `store.blog-home`, `store.blog-category`, `store.blog-post`, `store.blog-search-result` pages.
 
 ## [2.42.1] - 2019-07-15
 

--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,7 @@
     "vtex.product-availability": "0.x",
     "vtex.product-quantity": "1.x",
     "vtex.shop-review-interfaces": "0.x",
+    "vtex.blog-interfaces": "0.x",
     "vtex.product-identifier": "0.x",
     "vtex.open-graph": "1.x",
     "vtex.sticky-layout": "0.x"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -59,7 +59,8 @@
       "share",
       "product-highlights",
       "product-availability",
-      "product-identifier"
+      "product-identifier",
+      "blog-related-posts"
     ],
     "context": "ProductContext",
     "preview": {
@@ -105,6 +106,43 @@
       "type": "spinner",
       "height": 800
     }
+  },
+  "store.blog-home": {
+    "before": ["header.full"],
+    "allowed": [
+      "blog-all-posts",
+      "blog-latest-posts-preview",
+      "blog-category-preview",
+      "blog-search"
+    ]
+  },
+  "store.blog-category": {
+    "before": ["header.full"],
+    "required": [
+      "blog-category-list"
+    ],
+    "allowed": [
+      "blog-search",
+      "blog-category-preview"
+    ]
+  },
+  "store.blog-post": {
+    "before": ["header.full"],
+    "required": [
+      "blog-post-details"
+    ],
+    "allowed": [
+      "blog-search"
+    ]
+  },
+  "store.blog-search-result": {
+    "before": ["header.full"],
+    "required": [
+      "blog-search-list"
+    ],
+    "allowed": [
+      "blog-search"
+    ]
   },
   "storeWrapper": {
     "allowed": ["highlight-overlay"],


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add store blog pages needed by vtex.wordpress-integration

#### What problem is this solving?

For the Wordpress integration app (and any future blog integrations) vtex.store now defines page interfaces for store.blog-home, store.blog-post, store.blog-category, and store.blog-search-result . 

A separate app, vtex.blog-interfaces, defines abstract interfaces for the block components of these pages.

#### How should this be manually tested?
Example blog pages can be seen here:

https://wordpresstest--storecomponents.myvtex.com/blog
https://wordpresstest--storecomponents.myvtex.com/blog/category/410
https://wordpresstest--storecomponents.myvtex.com/blog/post/13189
https://wordpresstest--storecomponents.myvtex.com/blog/search/tim%20clarke

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
