### PR TITLE
Use storeName instead of titleTag on page title.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Uses store name as suffix on Product and Search context pages instead of title tag.
 
 ## [2.46.1] - 2019-07-29
 ### Removed

--- a/react/ProductWrapper.js
+++ b/react/ProductWrapper.js
@@ -232,7 +232,7 @@ const ProductWrapper = ({
     if (settings) {
       const { storeName, titleTag: storeTitleTag } = settings
       const suffix =
-        (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
+        (storeName || storeTitleTag) && ` - ${storeName || storeTitleTag}`
       if (suffix) {
         title += suffix
       }

--- a/react/SearchWrapper.js
+++ b/react/SearchWrapper.js
@@ -74,12 +74,16 @@ const SearchWrapper = props => {
   useDataPixel(pixelEvents, loading)
 
   const settings = getSettings(APP_LOCATOR) || {}
-  const { titleTag: storeTitle, metaTagKeywords } = settings
+  const { titleTag: defaultStoreTitle, metaTagKeywords, storeName } = settings
 
   return (
     <Fragment>
       <Helmet
-        title={getTitleTag(titleTag, storeTitle, params.term)}
+        title={getTitleTag(
+          titleTag,
+          storeName || defaultStoreTitle,
+          params.term
+        )}
         meta={[
           params.term && {
             name: 'keywords',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change the suffix used on product pages and search pages.

#### What problem is this solving?

The suffix used nowadays is the "Default title tag", which can be a bit misleading since it's the title used both as a fallback and as the suffix for the pages mentioned above. This PR makes the store name the suffix added to the title.

#### How should this be manually tested?
[Workspace](https://storename--storecomponents.myvtex.com/)

1. Change the "Store Name" and the "Default title tag" on [the Store Settings](https://storename--storecomponents.myvtex.com/admin/cms/storefront).
2. Access a [product page](https://storename--storecomponents.myvtex.com/shirt/p) and check the suffix..
3. Access a [search page](https://storename--storecomponents.myvtex.com/apparel---accessories/hats/) and check the suffix.
4. Access a [page without title](https://storename--storecomponents.myvtex.com/about-us) and check the title.

#### Screenshots or example usage

<img width="670" alt="Screen Shot 2019-07-29 at 18 00 06" src="https://user-images.githubusercontent.com/10400340/62082240-be255900-b22a-11e9-815e-3da2f487e10f.png">

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
