### PR TITLE
fixed default orderby on searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The default order by option is now `relevance`
 
 ## [2.47.0] - 2019-07-30
 ### Changed

--- a/react/utils/search.js
+++ b/react/utils/search.js
@@ -1,31 +1,35 @@
 export const SORT_OPTIONS = [
   {
+    value: '',
+    label: 'store/ordenation.relevance',
+  },
+  {
     value: 'OrderByTopSaleDESC',
-    label: 'ordenation.sales',
+    label: 'store/ordenation.sales',
   },
   {
     value: 'OrderByReleaseDateDESC',
-    label: 'ordenation.release.date',
+    label: 'store/ordenation.release.date',
   },
   {
     value: 'OrderByBestDiscountDESC',
-    label: 'ordenation.discount',
+    label: 'store/ordenation.discount',
   },
   {
     value: 'OrderByPriceDESC',
-    label: 'ordenation.price.descending',
+    label: 'store/ordenation.price.descending',
   },
   {
     value: 'OrderByPriceASC',
-    label: 'ordenation.price.ascending',
+    label: 'store/ordenation.price.ascending',
   },
   {
     value: 'OrderByNameASC',
-    label: 'ordenation.name.ascending',
+    label: 'store/ordenation.name.ascending',
   },
   {
     value: 'OrderByNameDESC',
-    label: 'ordenation.name.descending',
+    label: 'store/ordenation.name.descending',
   },
 ]
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make "relevance" the default orderby

#### What problem is this solving?

The current default orderby is "sales" when it was supposed to be "relevance"

#### How should this be manually tested?
[workspace](https://iaronaraujo--alssports.myvtex.com/clothing/Jackets/Womens?map=c%2Cc%2CspecificationFilter_7721)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8443580/62161941-977c2680-b2ed-11e9-8ced-d4bfa8f9a6b6.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
