### PR TITLE
Allow product-teaser.product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow `product-teaser.product`.
 
 ## [2.46.1] - 2019-07-29
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,8 @@
     "vtex.product-identifier": "0.x",
     "vtex.open-graph": "1.x",
     "vtex.sticky-layout": "0.x",
-    "vtex.product-customizer": "2.x"
+    "vtex.product-customizer": "2.x",
+    "vtex.product-teaser-interfaces": "1.x"
   },
   "settingsSchema": {
     "title": "VTEX Store",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -61,7 +61,8 @@
       "product-availability",
       "product-identifier",
       "blog-related-posts",
-      "product-assembly-options"
+      "product-assembly-options",
+      "product-teaser.product"
     ],
     "context": "ProductContext",
     "preview": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow to add product-teaser-interfaces to the product page.

#### What problem is this solving?

Integrate with https://docs.affirm.com/Integrate_Affirm/Promotional_Messaging

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/work-shirt/p

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/62238105-ad9aed00-b3a8-11e9-8076-da3f746c98a7.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
