### PR TITLE
Fix issue when filtering in a department page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Bug when filtering in a department page
 
 ## [2.50.0] - 2019-08-21
 ### Removed

--- a/react/SearchContext.js
+++ b/react/SearchContext.js
@@ -30,7 +30,9 @@ const SearchContext = ({
   const { page: runtimePage } = useRuntime()
   const map = mapQuery || initializeMap(params)
 
-  const query = Object.values(params)
+  // Remove params which don't compose a search path
+  const { id, ...searchParams } = params
+  const query = Object.values(searchParams)
     .filter(term => term && term.length > 0)
     .join('/')
     .replace(/\/\//g, '/') //This cleans some bad cases of two // on some terms.


### PR DESCRIPTION
#### What problem is this solving?

Open a department page
https://storecomponents.myvtex.com/apparel---accessories/
Click on Kawasaki
Check that the URL have `/25/` and I didn't filter by Kawasaki

Do the same thing here:
https://breno--storecomponents.myvtex.com/apparel---accessories/

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
