### PR TITLE
Add store.search to prefetch default pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prefetch `store.search` and `store.custom` pages
 
 ## [2.50.1] - 2019-08-21
 ### Fixed

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -79,7 +79,18 @@ class StoreWrapper extends Component {
     const {
       runtime: { prefetchDefaultPages },
     } = this.props
-    prefetchDefaultPages(['store.product'])
+    prefetchDefaultPages([
+      'store.custom',
+      'store.product',
+      'store.search',
+      'store.search#brand',
+      'store.search#category',
+      'store.search#configurable',
+      'store.search#custom',
+      'store.search#department',
+      'store.search#subcategory',
+      'store.search#subcategory-terms',
+    ])
   }
 
   render() {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add store.search to prefetch default pages

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
