### PR TITLE
fix redirect to search page in ProductContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fxi redirect of empty product to `store.search` page.
 
 ## [2.52.0] - 2019-08-23
 

--- a/react/ProductContext.js
+++ b/react/ProductContext.js
@@ -12,6 +12,8 @@ import {
 
 import { cacheLocator } from './cacheLocator'
 
+const emptyOrNull = value => (value != null ? isEmpty(value) : true)
+
 const useProduct = props => {
   const {
     catalog: { product: catalogProduct, loading: catalogLoading = true } = {},
@@ -24,7 +26,7 @@ const useProduct = props => {
   const catalogInfo = !catalogLoading && catalogProduct
   const benefitsInfo = catalogInfo && !benefitsLoading && benefitsProduct
   return useMemo(() => {
-    const bothEmpty = isEmpty(catalogInfo) && isEmpty(benefitsInfo)
+    const bothEmpty = emptyOrNull(catalogInfo) && emptyOrNull(benefitsInfo)
     return bothEmpty ? null : { ...catalogInfo, ...benefitsInfo }
   }, [benefitsInfo, catalogInfo])
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Previously, if the product query did not find anything, we would redirect the user to the store.search page as product not found.

After a refactor that I did, this behaviour stopped working.

Now I am bringing it back.

#### How should this be manually tested?

https://ieel--storecomponents.myvtex.com/teste/p

Should redirect to search page.

https://ieel--storecomponents.myvtex.com/classic-shoes/p

Should work just fine.

Compare with https://storetheme.vtex.com/teste/p

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
