### PR TITLE
Added blog-breadcrumb as allowed block on blog pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Made `blog-breadcrumb` an allowed block on blog pages.
 
 ## [2.53.2] - 2019-08-30
 ### Fixed

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -113,6 +113,7 @@
     "before": ["header.full"],
     "allowed": [
       "blog-all-posts",
+      "blog-breadcrumb",
       "blog-latest-posts-preview",
       "blog-category-preview",
       "blog-search"
@@ -121,17 +122,17 @@
   "store.blog-category": {
     "before": ["header.full"],
     "required": ["blog-category-list"],
-    "allowed": ["blog-search", "blog-category-preview"]
+    "allowed": ["blog-breadcrumb", "blog-search", "blog-category-preview"]
   },
   "store.blog-post": {
     "before": ["header.full"],
     "required": ["blog-post-details"],
-    "allowed": ["blog-search"]
+    "allowed": ["blog-breadcrumb", "blog-search"]
   },
   "store.blog-search-result": {
     "before": ["header.full"],
     "required": ["blog-search-list"],
-    "allowed": ["blog-search"]
+    "allowed": ["blog-breadcrumb", "blog-search"]
   },
   "storeWrapper": {
     "allowed": ["highlight-overlay"],


### PR DESCRIPTION
#### What is the purpose of this pull request?

`blog-breadcrumb` has been added as an allowed block on blog pages.

#### What problem is this solving?

This is an additional feature that I've developed for the Wordpress integration (`vtex.wordpress-integration`).

#### How should this be manually tested?

View example page here: https://wordpress--worldwidegolf.myvtex.com/insider/post/13260
(blog breadcrumb is at top of page)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
