### PR TITLE
Add Google Searchbox script to head in Storewrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add structured-data dependency.
-- Add GoogleSearchBox component in storewrapper.
+- Add SearchAction component in StoreWrapper.
 
 ## [2.53.4] - 2019-09-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add structured-data dependency.
+- Add GoogleSearchBox component in storewrapper.
 
 ## [2.53.4] - 2019-09-02
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -48,7 +48,8 @@
     "vtex.open-graph": "1.x",
     "vtex.sticky-layout": "0.x",
     "vtex.product-customizer": "2.x",
-    "vtex.product-teaser-interfaces": "1.x"
+    "vtex.product-teaser-interfaces": "1.x",
+    "vtex.structured-data": "0.x"
   },
   "settingsSchema": {
     "title": "VTEX Store",

--- a/react/HomeWrapper.js
+++ b/react/HomeWrapper.js
@@ -1,6 +1,7 @@
-import { useMemo } from 'react'
+import React, { useMemo, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { useRuntime } from 'vtex.render-runtime'
+import SearchAction from 'vtex.structured-data/SearchAction'
 
 import useDataPixel from './hooks/useDataPixel'
 
@@ -34,7 +35,12 @@ const HomeWrapper = ({ children }) => {
   }, [account])
   useDataPixel(pixelEvents, 'Home')
 
-  return children
+  return (
+    <Fragment>
+      <SearchAction />
+      {children}
+    </Fragment>
+  )
 }
 
 HomeWrapper.propTypes = {

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types'
 import { PixelProvider } from 'vtex.pixel-manager/PixelContext'
 import { ToastProvider } from 'vtex.styleguide'
 import { PWAProvider } from 'vtex.store-resources/PWAContext'
-import GoogleSearchBox from 'vtex.structured-data/GoogleSearchBox'
+import SearchAction from 'vtex.structured-data/SearchAction'
 
 import PageViewPixel from './components/PageViewPixel'
 import OrderFormProvider from './components/OrderFormProvider'
@@ -175,7 +175,7 @@ class StoreWrapper extends Component {
             <ExtensionPoint id="highlight-overlay" />
           </NoSSR>
         )}
-        <GoogleSearchBox />
+        {route && route.id === 'store.home' && <SearchAction />}
       </Fragment>
     )
   }

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types'
 import { PixelProvider } from 'vtex.pixel-manager/PixelContext'
 import { ToastProvider } from 'vtex.styleguide'
 import { PWAProvider } from 'vtex.store-resources/PWAContext'
+import GoogleSearchBox from 'vtex.structured-data/GoogleSearchBox'
 
 import PageViewPixel from './components/PageViewPixel'
 import OrderFormProvider from './components/OrderFormProvider'
@@ -174,6 +175,7 @@ class StoreWrapper extends Component {
             <ExtensionPoint id="highlight-overlay" />
           </NoSSR>
         )}
+        <GoogleSearchBox />
       </Fragment>
     )
   }

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types'
 import { PixelProvider } from 'vtex.pixel-manager/PixelContext'
 import { ToastProvider } from 'vtex.styleguide'
 import { PWAProvider } from 'vtex.store-resources/PWAContext'
-import SearchAction from 'vtex.structured-data/SearchAction'
 
 import PageViewPixel from './components/PageViewPixel'
 import OrderFormProvider from './components/OrderFormProvider'
@@ -175,7 +174,6 @@ class StoreWrapper extends Component {
             <ExtensionPoint id="highlight-overlay" />
           </NoSSR>
         )}
-        {route && route.id === 'store.home' && <SearchAction />}
       </Fragment>
     )
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adding Google Search Box script in the head to show the input search for the store in google search

![image](https://user-images.githubusercontent.com/20094423/64050121-b2d09080-cb3c-11e9-84fb-053dd332e6c2.png)

#### How should this be manually tested?
go to https://vtexcamilo--exitocol.myvtex.com/ in the elements should be with the script

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/20094423/64050066-8caaf080-cb3c-11e9-8347-145716e63006.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
