### PR TITLE
Fix/structured data description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Uses `metaTagDescription` instead of `description` on product structured data, which fixes an issue where scripts added to the description would break the page.
 
 ## [2.53.6] - 2019-09-02
 ### Fixed

--- a/react/components/StructuredData.js
+++ b/react/components/StructuredData.js
@@ -141,7 +141,6 @@ const parseToJsonLD = (product, selectedItem, currency, locale) => {
   const image = head(path(['images'], selectedItem))
   const brand = product.brand
   const name = product.productName
-  const description = tryParsingLocale(product.description, locale)
 
   const productLD = {
     '@context': 'https://schema.org/',
@@ -149,7 +148,7 @@ const parseToJsonLD = (product, selectedItem, currency, locale) => {
     name: name,
     brand: brand,
     image: image && image.imageUrl,
-    description: description,
+    description: product.metaTagDescription,
     mpn: product.productId,
     sku: selectedItem.itemId,
     offers: composeAggregateOffer(product, currency),


### PR DESCRIPTION
#### What is the purpose of this pull request?
Uses `metaTagDescription` instead of `description` on product structured data, which fixes an issue where scripts added to the description would break the page.

https://lbebber2--exitocol.myvtex.com/celular-samsung-galaxy-a9-128gb-6gb-negro-40407/p

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
