### PR TITLE
Remove keywords metatag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Meta tag `keywords` from manifest and components that still used it.
+- Meta tag `robots` from manifest and `StoreWrapper`.
+
 ## [2.54.0] - 2019-09-09
 ### Changed
 - Trigger `productView` when selected SKU changes.
@@ -42,7 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.53.0] - 2019-08-28
 ### Changed
-- PWA helmet and query in `StoreWrapper` and move it to `PWAProvider`. 
+- PWA helmet and query in `StoreWrapper` and move it to `PWAProvider`.
 
 ## [2.52.3] - 2019-08-27
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -71,11 +71,6 @@
         "title": "Meta description tag",
         "type": "string"
       },
-      "metaTagRobots": {
-        "title": "Meta robots tag",
-        "type": "string",
-        "description": "Default value: index, follow"
-      },
       "faviconLinks": {
         "title": "Favicons",
         "type": "array",

--- a/manifest.json
+++ b/manifest.json
@@ -71,10 +71,6 @@
         "title": "Meta description tag",
         "type": "string"
       },
-      "metaTagKeywords": {
-        "title": "Meta keywords tag",
-        "type": "string"
-      },
       "metaTagRobots": {
         "title": "Meta robots tag",
         "type": "string",
@@ -107,10 +103,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "Configure your store's favicons"
       }

--- a/react/SearchWrapper.js
+++ b/react/SearchWrapper.js
@@ -52,7 +52,7 @@ const SearchWrapper = props => {
   } = props
   const { account, getSettings } = useRuntime()
   const settings = getSettings(APP_LOCATOR) || {}
-  const { titleTag: defaultStoreTitle, metaTagKeywords, storeName } = settings
+  const { titleTag: defaultStoreTitle, storeName } = settings
   const title = getTitleTag(
     titleTag,
     storeName || defaultStoreTitle,
@@ -108,10 +108,6 @@ const SearchWrapper = props => {
       <Helmet
         title={title}
         meta={[
-          params.term && {
-            name: 'keywords',
-            content: `${params.term}, ${metaTagKeywords}`,
-          },
           params.term && {
             name: 'robots',
             content: 'noindex,follow',

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -97,13 +97,7 @@ class StoreWrapper extends Component {
       },
     } = this.props
     const settings = getSettings(APP_LOCATOR) || {}
-    const {
-      titleTag,
-      metaTagDescription,
-      metaTagRobots,
-      storeName,
-      faviconLinks,
-    } = settings
+    const { titleTag, metaTagDescription, storeName, faviconLinks } = settings
 
     const { canonicalHost, canonicalPath } = systemToCanonical(route)
     const description = (metaTags && metaTags.description) || metaTagDescription
@@ -123,7 +117,7 @@ class StoreWrapper extends Component {
             { name: 'country', content: country },
             { name: 'language', content: locale },
             { name: 'currency', content: currency },
-            { name: 'robots', content: metaTagRobots || META_ROBOTS },
+            { name: 'robots', content: META_ROBOTS },
             { httpEquiv: 'Content-Type', content: CONTENT_TYPE },
           ]}
           script={[

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -30,10 +30,6 @@ const systemToCanonical = ({ canonicalPath }) => {
   }
 }
 
-const joinKeywords = keywords => {
-  return keywords && keywords.length > 0 ? keywords.join(', ') : ''
-}
-
 class StoreWrapper extends Component {
   static propTypes = {
     runtime: PropTypes.shape({
@@ -104,7 +100,6 @@ class StoreWrapper extends Component {
     const {
       titleTag,
       metaTagDescription,
-      metaTagKeywords,
       metaTagRobots,
       storeName,
       faviconLinks,
@@ -112,8 +107,6 @@ class StoreWrapper extends Component {
 
     const { canonicalHost, canonicalPath } = systemToCanonical(route)
     const description = (metaTags && metaTags.description) || metaTagDescription
-    const keywords =
-      joinKeywords(metaTags && metaTags.keywords) || metaTagKeywords
     const title = pageTitle || titleTag
 
     const [queryMatch] = route.path.match(/\?.*/) || ['?']
@@ -125,7 +118,6 @@ class StoreWrapper extends Component {
           meta={[
             { name: 'viewport', content: MOBILE_SCALING },
             { name: 'description', content: description },
-            { name: 'keywords', content: keywords },
             { name: 'copyright', content: storeName },
             { name: 'author', content: storeName },
             { name: 'country', content: country },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove the `keywords` field  from `manifest.json` since it isn't used by [Google](https://youtu.be/jK7IPbnmvVU
) and other search engines for almost a decade, as pointed by @rgoytacaz.

#### What problem is this solving?

Useless field that only adds noise.

#### How should this be manually tested?

[Home](https://nokeywords--storecomponents.myvtex.com/)
[Site Editor](https://nokeywords--storecomponents.myvtex.com/admin/cms/site-editor)

#### Screenshots or example usage

<img width="517" alt="Screen Shot 2019-09-06 at 15 16 47" src="https://user-images.githubusercontent.com/10400340/64450872-5f6cbe00-d0b9-11e9-83ca-949702163088.png">

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
