### PR TITLE
remove product context logic, use provider from app, fix tests

### DIFF
--- a/react/__mocks__/vtex.product-context/ProductContextProvider.js
+++ b/react/__mocks__/vtex.product-context/ProductContextProvider.js
@@ -1,0 +1,15 @@
+import React, { createContext } from 'react'
+
+export const ProductContext = createContext({})
+
+const ProductContextProvider = ({ product, children }) => {
+  return (
+    <ProductContext.Provider
+      value={{ product, selectedItem: product.items[0] }}
+    >
+      {children}
+    </ProductContext.Provider>
+  )
+}
+
+export default ProductContextProvider

--- a/react/__mocks__/vtex.product-context/useProduct.js
+++ b/react/__mocks__/vtex.product-context/useProduct.js
@@ -1,0 +1,5 @@
+import { useContext } from 'react'
+import { ProductContext } from './ProductContextProvider'
+
+const useProduct = () => useContext(ProductContext)
+export default useProduct

--- a/react/__tests__/ProductWrapper.test.js
+++ b/react/__tests__/ProductWrapper.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React, { useContext } from 'react'
 import { render } from '@vtex/test-tools/react'
-import { getProduct, getItem } from '../__mocks__/productMock'
+import { getProduct } from '../__mocks__/productMock'
 import ProductWrapper from '../ProductWrapper'
 import { ProductContext } from '../__mocks__/vtex.product-context'
 
@@ -45,10 +45,6 @@ describe('ProductWrapper component', () => {
     return {
       ...component,
       getTitleTag: product => getByText(new RegExp(product.titleTag)),
-      getSelectedItemId: item => getByText(`Selected Item id: ${item.itemId}`),
-      getSelectedItemName: item =>
-        getByText(`Selected Item name: ${item.name}`),
-      getProductSlug: product => getByText(`product slug: ${product.linkText}`),
     }
   }
 
@@ -69,96 +65,5 @@ describe('ProductWrapper component', () => {
     })
     getByTestId(descriptionId)
     getTitleTag(product)
-  })
-
-  it('should switch items and reset state', () => {
-    const product = getProduct()
-    const {
-      rerender,
-      getTitleTag,
-      getSelectedItemId,
-      getSelectedItemName,
-      getProductSlug,
-    } = renderComponent()
-
-    const newItem = getItem('2')
-    const newProduct = getProduct({
-      items: [newItem],
-      productId: '2',
-      linkText: 'product-slug-2',
-      titleTag: 'Product 2',
-      productName: 'Product 2',
-    })
-
-    getTitleTag(product)
-    getSelectedItemId(product.items[0])
-    getSelectedItemName(product.items[0])
-    getProductSlug(product)
-    const newProps = {
-      product: newProduct,
-      params: { slug: newProduct.linkText },
-      productQuery: { product: newProduct, loading: false },
-    }
-    rerender(
-      <ProductWrapper {...getProps(newProps)}>
-        <ProductPageMock />
-      </ProductWrapper>
-    )
-
-    getTitleTag(newProduct)
-    getSelectedItemId(newProduct.items[0])
-    getSelectedItemName(newProduct.items[0])
-    getProductSlug(newProduct)
-  })
-
-  it('should select first item with available quantity', async () => {
-    const noQuantity = getItem('no quantity', 90, 0)
-    const itemWithQuantity = getItem('Item with quantity', 90, 10)
-    const otherItemWithQuantity = getItem('other item with quantity', 90, 10)
-    const newProduct = getProduct({
-      items: [noQuantity, noQuantity, itemWithQuantity, otherItemWithQuantity],
-    })
-    const { getSelectedItemId, getSelectedItemName } = renderComponent({
-      product: newProduct,
-      params: { slug: newProduct.linkText },
-      productQuery: { product: newProduct, loading: false },
-    })
-
-    getSelectedItemId(itemWithQuantity)
-    getSelectedItemName(itemWithQuantity)
-  })
-
-  it('should switch items when changing query prop', async () => {
-    const itemone = getItem('1', 90, 1)
-    const itemtwo = getItem('2', 90, 10)
-    const itemthree = getItem('3', 90, 10)
-    const newProduct = getProduct({
-      items: [itemone, itemtwo, itemthree],
-    })
-    const props = {
-      product: newProduct,
-      params: { slug: newProduct.linkText },
-      productQuery: { product: newProduct, loading: false },
-    }
-    const {
-      getSelectedItemId,
-      getSelectedItemName,
-      rerender,
-    } = renderComponent(props)
-
-    getSelectedItemId(itemone)
-    getSelectedItemName(itemone)
-
-    const newProps = {
-      ...props,
-      query: { skuId: itemtwo.itemId },
-    }
-    rerender(
-      <ProductWrapper {...getProps(newProps)}>
-        <ProductPageMock />
-      </ProductWrapper>
-    )
-    getSelectedItemId(itemtwo)
-    getSelectedItemName(itemtwo)
   })
 })

--- a/react/__tests__/StructuredData.test.ts
+++ b/react/__tests__/StructuredData.test.ts
@@ -1,0 +1,53 @@
+import { parseToJsonLD } from '../components/StructuredData'
+import { getProduct, getItem } from '../__mocks__/productMock'
+
+describe('teste parse to json logic', () => {
+  it('test low and high offer logic', () => {
+    const cheapItem = getItem('2', 45, 1)
+    const product = getProduct()
+    product.items.push(cheapItem)
+
+    const currency = 'BRL'
+    const result = JSON.parse(
+      parseToJsonLD(product, product.items[1], currency)
+    )
+
+    expect(result.offers.lowPrice).toBe(
+      cheapItem.sellers[0].commertialOffer.Price
+    )
+    expect(result.offers.highPrice).toBe(
+      product.items[0].sellers[0].commertialOffer.Price
+    )
+    expect(result.offers.priceCurrency).toBe(currency)
+    expect(result.sku).toBe(cheapItem.itemId)
+  })
+  it('test availability logic', () => {
+    const cheapItem = getItem('2', 45, 0)
+    const itemAvailable = getItem('3', 60, 1)
+    const product = getProduct()
+    product.items.push(cheapItem)
+    product.items.push(itemAvailable)
+
+    const currency = 'BRL'
+    const result = JSON.parse(
+      parseToJsonLD(product, product.items[0], currency)
+    )
+
+    expect(result.offers.lowPrice).toBe(
+      cheapItem.sellers[0].commertialOffer.Price
+    )
+    expect(result.offers.highPrice).toBe(
+      product.items[0].sellers[0].commertialOffer.Price
+    )
+    expect(result.offers.priceCurrency).toBe(currency)
+    expect(result.offers.offers[0].availability).toBe(
+      'http://schema.org/InStock'
+    )
+    expect(result.offers.offers[1].availability).toBe(
+      'http://schema.org/OutOfStock'
+    )
+    expect(result.offers.offers[2].availability).toBe(
+      'http://schema.org/InStock'
+    )
+  })
+})

--- a/react/components/StructuredData.js
+++ b/react/components/StructuredData.js
@@ -54,18 +54,6 @@ const lowestPriceInStockSKU = sku => {
   }
 }
 
-const tryParsingLocale = (description, locale) => {
-  let parsedDescription
-  try {
-    const descriptionObject = JSON.parse(description)
-    parsedDescription =
-      descriptionObject[locale] || descriptionObject[head(split('-', locale))]
-  } catch (e) {
-    console.warn('Failed to parse multilanguage product description')
-  }
-  return parsedDescription || description
-}
-
 const highestPriceItem = compose(
   last,
   sort(
@@ -137,7 +125,7 @@ const composeAggregateOffer = (product, currency) => {
   return aggregateOffer
 }
 
-const parseToJsonLD = (product, selectedItem, currency, locale) => {
+export const parseToJsonLD = (product, selectedItem, currency) => {
   const image = head(path(['images'], selectedItem))
   const brand = product.brand
   const name = product.productName


### PR DESCRIPTION
#### What is the purpose of this pull request?

Move logic related to ProductContext to its own app.

Fix tests, only test title related data at ProductWrapper

Add basic tests to structured data.

To test: navigate to PDP

#### How should this be manually tested?
https://fidelis--storecomponents.myvtex.com/

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
