### PR TITLE
Remove amphtml link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- `amphtml` helmet link.
 
 ## [2.58.0] - 2019-09-13
 ### Added

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -151,10 +151,10 @@ class StoreWrapper extends Component {
             ...(faviconLinks || []),
             ...(!amp && canonicalLink
               ? [
-                  {
+                  /*{
                     rel: 'amphtml',
                     href: encodeURI(`${canonicalLink}?amp`),
-                  },
+                  },*/
                   {
                     rel: 'canonical',
                     href: encodeURI(canonicalLink),


### PR DESCRIPTION
#### What is the purpose of this pull request?
Removes the `amphtml` helmet link.

#### What problem is this solving?
Google Search Console was emitting an error saying the page wasn't a valid AMP page. We initially released this because we didn't know there was a problem in always linking to the `amphtml`.

#### How should this be manually tested?
[Workspace](https://lucas--delivery.myvtex.com/)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.