### PR TITLE
Feature/fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `__fold__` blocks, along with `mobile` and `desktop` variants, to be able to set what lies "below the fold".
 
 ## [2.58.2] - 2019-09-16
 

--- a/react/Fold.js
+++ b/react/Fold.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const Fold = () => <React.Fragment />
+
+export default Fold

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -17,7 +17,8 @@
       "flex-layout",
       "sandbox",
       "image",
-      "sticky-layout"
+      "sticky-layout",
+      "__fold__"
     ],
     "preview": {
       "type": "transparent",
@@ -169,5 +170,10 @@
   },
   "store.content": {
     "context": "ContentPageContext"
-  }
+  },
+  "__fold__": {
+    "component": "Fold"
+  },
+  "__fold__.mobile": {},
+  "__fold__.desktop": {}
 }


### PR DESCRIPTION
Adds support for `__fold__` blocks, to enable the user to set which content lies below the fold.

Test on https://lbebber5--storecomponents.myvtex.com/ (the fold is set just above the shelf at the home)

Works in tandem with https://github.com/vtex-apps/render-runtime/pull/409