### PR TITLE
Add slider-layout to allowed components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `slider-layout` block from `vtex.slider-layout` as allowed.
 
 ## [2.60.3] - 2019-09-20
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -46,6 +46,7 @@
     "vtex.blog-interfaces": "0.x",
     "vtex.product-identifier": "0.x",
     "vtex.open-graph": "1.x",
+    "vtex.slider-layout": "0.x",
     "vtex.sticky-layout": "0.x",
     "vtex.product-customizer": "2.x",
     "vtex.product-teaser-interfaces": "1.x",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -18,6 +18,7 @@
       "sandbox",
       "image",
       "sticky-layout",
+      "slider-layout",
       "__fold__",
       "tab-layout",
       "tab-list",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `slider-layout` to allowed blocks on the `store` interface.

#### How should this be manually tested?

https://sliderlayout--storecomponents.myvtex.com/about-us

This page uses 3 `slider-layout` blocks, each of them with a different children type.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
