### PR TITLE
Allow search-result-layout on store.custom

### DIFF
--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -166,7 +166,7 @@
     "component": "*"
   },
   "store.custom": {
-    "allowed": ["search-result"]
+    "allowed": ["search-result", "search-result-layout"]
   },
   "store.content": {
     "context": "ContentPageContext"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow the new flexible search result on custom pages

#### What problem is this solving?
Using the flexible search-result on custom pages without the default SearchContext, like this one which has a custom URL but it queries a collection id: https://www.paguemenos.com.br/danone

#### Screenshots or example usage
I've added the search-resyout-layout blocks on store.search pages (https://searchresultlayout--paguemenos.myvtex.com/medicamentos-e-saude), couldn't do it on store.custom 

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
