### PR TITLE
Add tab-layout interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `tab-layout`, `tab-content`, and `tab-list` blocks from `vtex.tab-layout`
 
 ## [2.60.2] - 2019-09-20
 

--- a/manifest.json
+++ b/manifest.json
@@ -49,7 +49,8 @@
     "vtex.sticky-layout": "0.x",
     "vtex.product-customizer": "2.x",
     "vtex.product-teaser-interfaces": "1.x",
-    "vtex.structured-data": "0.x"
+    "vtex.structured-data": "0.x",
+    "vtex.tab-layout": "0.x"
   },
   "settingsSchema": {
     "title": "VTEX Store",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -18,7 +18,10 @@
       "sandbox",
       "image",
       "sticky-layout",
-      "__fold__"
+      "__fold__",
+      "tab-layout",
+      "tab-list",
+      "tab-content"
     ],
     "preview": {
       "type": "transparent",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow `vtex.tab-layout`'s blocks on `store`.

#### What problem is this solving?

Allows users to create tabbed layouts on store pages.

#### How should this be manually tested?
See https://tablayout--storecomponents.myvtex.com/ for a working example

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
