### PR TITLE
Remove prefetch default pages for test purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.62.1-beta] - 2019-09-26
+
 ### Changed
 - Remove prefetch of pages to test impact on load time
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Remove prefetch of pages to test impact on load time
+
 ## [2.62.0] - 2019-09-24
 
 ## [2.61.1] - 2019-09-23
 ### Fixed
-- Strctured data not filtering out of stock sellers correctly.
+- Structured data not filtering out of stock sellers correctly.
 
 ## [2.61.0] - 2019-09-23
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -9,9 +9,6 @@
     "messages": "1.x",
     "react": "3.x"
   },
-  "scripts": {
-    "postreleasy": "vtex publish --verbose"
-  },
   "peerDependencies": {
     "vtex.store-sitemap": "1.x"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.62.0",
+  "version": "2.62.1-beta",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {
@@ -102,7 +102,10 @@
               "type": "string"
             }
           },
-          "required": ["rel", "href"]
+          "required": [
+            "rel",
+            "href"
+          ]
         },
         "description": "Configure your store's favicons"
       }

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -69,24 +69,6 @@ class StoreWrapper extends Component {
   isStorefrontIframe =
     canUseDOM && window.top !== window.self && window.top.__provideRuntime
 
-  componentDidMount() {
-    const {
-      runtime: { prefetchDefaultPages },
-    } = this.props
-    prefetchDefaultPages([
-      'store.custom',
-      'store.product',
-      'store.search',
-      'store.search#brand',
-      'store.search#category',
-      'store.search#configurable',
-      'store.search#custom',
-      'store.search#department',
-      'store.search#subcategory',
-      'store.search#subcategory-terms',
-    ])
-  }
-
   render() {
     const {
       runtime: {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Google Analytics load time apparently includes prefetching assets, *even if they're done 20 seconds after load happens.* :kaotico:

This is a test to check whether load time improves without prefetching the other pages. 

#### What problem is this solving?

Load times as measured by Google Analytics.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
