### PR TITLE
Allow `image-slider` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `image-list` and `image-slider` blocks from `vtex.store-image` as allowed.
+- `image-slider` block from `vtex.store-image` as allowed.
 
 ## [2.65.0] - 2019-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `image-list` and `image-slider` blocks from `vtex.store-image` as allowed.
 
 ## [2.65.0] - 2019-10-14
 

--- a/manifest.json
+++ b/manifest.json
@@ -52,7 +52,8 @@
     "vtex.pickup-availability": "0.x",
     "vtex.stack-layout": "0.x",
     "vtex.product-specification-badges": "0.x",
-    "vtex.visibility-layout": "0.x"
+    "vtex.visibility-layout": "0.x",
+    "vtex.store-image": "0.x"
   },
   "settingsSchema": {
     "title": "VTEX Store",
@@ -106,10 +107,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "Configure your store's favicons"
       }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -24,7 +24,8 @@
       "tab-list",
       "tab-content",
       "stack-layout",
-      "experimental__visibility-layout"
+      "experimental__visibility-layout",
+      "image-slider"
     ],
     "preview": {
       "type": "transparent",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `image-slider` block from `vtex.store-image` to allowed blocks at `store` interface.

#### What problem is this solving?

This should allow our users to use the new interfaces implemented by `vtex.store-image` app.

#### How should this be manually tested?

The first slider at
https://imageslider--storecomponents.myvtex.com/about-us is an `image-slider`.

**THIS SHOULD ONLY BE RELEASED AFTER**
- https://github.com/vtex-apps/slider-layout/pull/7
- https://github.com/vtex-apps/store-image/pull/3

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
