### PR TITLE
Add `responsive-layout` to allowed list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `responsive-layout` to allowed lists.
 
 ## [2.66.1] - 2019-10-15
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -53,7 +53,8 @@
     "vtex.stack-layout": "0.x",
     "vtex.product-specification-badges": "0.x",
     "vtex.visibility-layout": "0.x",
-    "vtex.store-image": "0.x"
+    "vtex.store-image": "0.x",
+    "vtex.responsive-layout": "0.x"
   },
   "settingsSchema": {
     "title": "VTEX Store",
@@ -107,10 +108,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "Configure your store's favicons"
       }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -25,7 +25,8 @@
       "tab-content",
       "stack-layout",
       "experimental__visibility-layout",
-      "image-slider"
+      "image-slider",
+      "responsive-layout"
     ],
     "preview": {
       "type": "transparent",


### PR DESCRIPTION
#### What is the purpose of this pull request?

All the new `responsive-layout` blocks to be used.

#### What problem is this solving?

It allows users to define layout blocks that will only be rendered on certain breakpoints.

#### How should this be manually tested?

https://victorhmp--storecomponents.myvtex.com/about-us

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
