### PR TITLE
protect against empty category tree on product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent crash on product page when product had empty category tree.
 
 ## [2.65.0] - 2019-10-14
 

--- a/react/__tests__/ProductWrapper.test.js
+++ b/react/__tests__/ProductWrapper.test.js
@@ -66,4 +66,14 @@ describe('ProductWrapper component', () => {
     getByTestId(descriptionId)
     getTitleTag(product)
   })
+
+  it('product wont break if category tree is an empty array', () => {
+    const product = getProduct({ categoryTree: [] })
+    const { getTitleTag } = renderComponent({
+      product,
+      params: { slug: product.linkText },
+      productQuery: { product, loading: false },
+    })
+    getTitleTag(product)
+  })
 })

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -53,20 +53,22 @@ function usePageEvents(titleTag: string, product: MaybeProduct, selectedItem: SK
       return []
     }
 
+    const hasCategoryTree = categoryTree && categoryTree.length
+
     const pageInfo: any = {
       event: 'pageInfo',
       eventType: 'productView',
       accountName: account,
       pageCategory: 'Product',
-      pageDepartment: categoryTree ? head(categoryTree).name : '',
+      pageDepartment: hasCategoryTree ? head(categoryTree!).name : '',
       pageFacets: [],
       pageTitle: titleTag,
       pageUrl: window.location.href,
       productBrandName: brand,
       productCategoryId: Number(categoryId),
-      productCategoryName: categoryTree ? last(categoryTree).name : '',
-      productDepartmentId: categoryTree ? head(categoryTree).id : '',
-      productDepartmentName: categoryTree ? head(categoryTree).name : '',
+      productCategoryName: hasCategoryTree ? last(categoryTree!).name : '',
+      productDepartmentId: hasCategoryTree ? head(categoryTree!).id : '',
+      productDepartmentName: hasCategoryTree ? head(categoryTree!).name : '',
       productId: productId,
       productName: productName,
       skuStockOutFromProductDetail: [],


### PR DESCRIPTION
#### What is the purpose of this pull request?

If categoryTree came as [], it would crash.

Add protection and test for it.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
