### PR TITLE
Remove custom wrapper from interfaces.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- `customWrapper` from `interfaces.json`
+
 ## [2.68.1] - 2019-10-22
 ### Fixed
 - Move code to vtex.structured-data.

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -158,9 +158,6 @@
   "searchWrapper": {
     "component": "SearchWrapper"
   },
-  "customWrapper": {
-    "component": "CustomWrapper"
-  },
   "challenge": {
     "component": "DefaultChallenge",
     "extensible": "public"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Apparently custom wrapper is not defined anymore as a component and doesn't need to be exposed in interfaces.json

#### What problem is this solving?

It confuses people on how to use custom blocks.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
