### PR TITLE
First implementation of search loading fix

### DIFF
--- a/react/SearchWrapper.js
+++ b/react/SearchWrapper.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Fragment, useMemo } from 'react'
+import React, { Fragment, useMemo, useState, useEffect } from 'react'
 import { Helmet, useRuntime, LoadingContextProvider } from 'vtex.render-runtime'
 
 import { capitalize } from './utils/capitalize'
@@ -101,6 +101,8 @@ const SearchWrapper = props => {
     ]
   }, [account, params, searchQuery, title])
 
+  const [isLoaded, setIsLoaded] = useState(true)
+
   const loadingValue = useMemo(
     () => ({
       isParentLoading: loading,
@@ -109,6 +111,11 @@ const SearchWrapper = props => {
   )
 
   useDataPixel(pixelEvents, getSearchIdentifier(searchQuery), loading)
+  useEffect(() => {
+    if (!loading) {
+      setIsLoaded(false)
+    }
+  }, [loading])
 
   return (
     <Fragment>
@@ -125,7 +132,7 @@ const SearchWrapper = props => {
           },
         ].filter(Boolean)}
       />
-      <LoadingContextProvider value={loadingValue}>
+      <LoadingContextProvider value={loadingValue && isLoaded}>
         {React.cloneElement(children, props)}
       </LoadingContextProvider>
     </Fragment>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixed stable loading for searches' setQuery. This brings back the double spinner issue though.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/)
Open a search or category and watch that when you change a facet or ordination type the loading is still as it was previously.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
