### PR TITLE
Use new OrderFormProvider and OrderQueueProvider contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New contexts from vtex.order-manager to the StoreWrapper component
 
 ## [2.73.0] - 2019-11-11
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -58,7 +58,8 @@
     "vtex.iframe": "0.x",
     "vtex.pwa-components": "0.x",
     "vtex.list-context": "0.x",
-    "vtex.menu": "2.x"
+    "vtex.menu": "2.x",
+    "vtex.order-manager": "0.x"
   },
   "settingsSchema": {
     "title": "VTEX Store",
@@ -112,10 +113,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "Configure your store's favicons"
       }

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -10,6 +10,8 @@ import PropTypes from 'prop-types'
 import { PixelProvider } from 'vtex.pixel-manager/PixelContext'
 import { ToastProvider } from 'vtex.styleguide'
 import { PWAProvider } from 'vtex.store-resources/PWAContext'
+import { OrderQueueProvider } from 'vtex.order-manager/OrderQueue'
+import { OrderFormProvider as OrderFormProviderCheckout } from 'vtex.order-manager/OrderForm'
 
 import PageViewPixel from './components/PageViewPixel'
 import OrderFormProvider from './components/OrderFormProvider'
@@ -169,9 +171,13 @@ class StoreWrapper extends Component {
             <ToastProvider positioning="window">
               <NetworkStatusToast />
               <OrderFormProvider>
-                <WrapperContainer className="vtex-store__template bg-base">
-                  {this.props.children}
-                </WrapperContainer>
+                <OrderQueueProvider>
+                  <OrderFormProviderCheckout>
+                    <WrapperContainer className="vtex-store__template bg-base">
+                      {this.props.children}
+                    </WrapperContainer>
+                  </OrderFormProviderCheckout>
+                </OrderQueueProvider>
               </OrderFormProvider>
             </ToastProvider>
           </PWAProvider>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add new contexts from `vtex.order-manager` to the `StoreWrapper` component so that they can be consumed by components created by the checkout-ui team. This is also necessary for the new minicart@3.x and `vtex.add-to-cart-button`.

#### What problem is this solving?

Without those two contexts, `add-to-cart-button` and `minicart@3.x` would not work :( .

#### How should this be manually tested?

[Workspace](minicart--storecomponents.myvtex.com)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
