### PR TITLE
Allow `menu` on `store` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `menu` to allowed list for `store` interface.
 
 ## [2.72.0] - 2019-11-08
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -57,7 +57,8 @@
     "vtex.responsive-layout": "0.x",
     "vtex.iframe": "0.x",
     "vtex.pwa-components": "0.x",
-    "vtex.list-context": "0.x"
+    "vtex.list-context": "0.x",
+    "vtex.menu": "2.x"
   },
   "settingsSchema": {
     "title": "VTEX Store",
@@ -111,10 +112,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "Configure your store's favicons"
       }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -27,7 +27,8 @@
       "experimental__visibility-layout",
       "image-slider",
       "responsive-layout",
-      "list-context"
+      "list-context",
+      "menu"
     ],
     "preview": {
       "type": "transparent",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enable users to use the `menu` block in every interface extending `store`, such as `store.home`.

#### What problem is this solving?

The `menu` could only be used inside the `header` block.

#### How should this be manually tested?

Notice that there is a menu right below the Shelf:
[Workspace](https://menustore--storecomponents.myvtex.com/)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

Should solve this: https://app.clubhouse.io/vtex/story/26033/allow-menu-on-store-home