### PR TITLE
Rename offline page route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Renamed offline page route to `/_v/offline`.
 
 ## [2.74.0] - 2019-11-11 [YANKED]
 ### Added	

--- a/store/routes.json
+++ b/store/routes.json
@@ -48,6 +48,6 @@
     "path": "/checkout/orderPlaced"
   },
   "store.offline": {
-    "path": "/offline"
+    "path": "/_v/offline"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Renames the offline page from `/offline` to `/_v/offline`.

#### What problem is this solving?
As discussed internally, we agreed that "offline" may be the name of some brand, and could cause conflicts with this route, so we decided to change it to refer to an internal route.

#### How should this be manually tested?
[Workspace](https://lucas2--storecomponents.myvtex.com/)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
