### PR TITLE
Check for support before adding register SW script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update to only add the register service worker script if the browser supports
+  it. This also changes to only add this script in the client-side.
 
 ## [2.75.0] - 2019-11-13
 ### Added	

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -1,10 +1,10 @@
-import React, { Component, Fragment } from 'react'
+import React, { Fragment, useEffect } from 'react'
 import {
   canUseDOM,
   ExtensionPoint,
   Helmet,
   NoSSR,
-  withRuntimeContext,
+  useRuntime,
 } from 'vtex.render-runtime'
 import PropTypes from 'prop-types'
 import { PixelProvider } from 'vtex.pixel-manager/PixelContext'
@@ -32,49 +32,23 @@ const systemToCanonical = ({ canonicalPath }) => {
   }
 }
 
-class StoreWrapper extends Component {
-  static propTypes = {
-    runtime: PropTypes.shape({
-      amp: PropTypes.boolean,
-      prefetchDefaultPages: PropTypes.func,
-      culture: PropTypes.shape({
-        country: PropTypes.string,
-        locale: PropTypes.string,
-        currency: PropTypes.string,
-      }),
-      route: PropTypes.shape({
-        metaTags: PropTypes.shape({
-          description: PropTypes.string,
-          keywords: PropTypes.arrayOf(PropTypes.string),
-        }),
-        title: PropTypes.string,
-      }),
-    }),
-    children: PropTypes.element,
-    push: PropTypes.func,
-    data: PropTypes.shape({
-      loading: PropTypes.bool,
-      manifest: PropTypes.shape({
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        theme_color: PropTypes.string,
-        icons: PropTypes.arrayOf(
-          PropTypes.shape({
-            src: PropTypes.string,
-            type: PropTypes.string,
-            sizes: PropTypes.string,
-          })
-        ),
-      }),
-    }),
-  }
+const StoreWrapper = ({ children }) => {
+  const {
+    amp,
+    culture: { country, locale, currency },
+    route,
+    route: { metaTags, title: pageTitle },
+    getSettings,
+    rootPath = '',
+    prefetchDefaultPages,
+  } = useRuntime()
 
-  isStorefrontIframe =
+  const isStorefrontIframe =
     canUseDOM && window.top !== window.self && window.top.__provideRuntime
 
-  componentDidMount() {
-    const {
-      runtime: { prefetchDefaultPages },
-    } = this.props
+  const supportsServiceWorker = canUseDOM && 'serviceWorker' in navigator
+
+  useEffect(() => {
     prefetchDefaultPages([
       'store.custom',
       'store.product',
@@ -87,109 +61,101 @@ class StoreWrapper extends Component {
       'store.search#subcategory',
       'store.search#subcategory-terms',
     ])
-  }
+  }, [prefetchDefaultPages])
 
-  render() {
-    const {
-      runtime: {
-        amp,
-        culture: { country, locale, currency },
-        route,
-        route: { metaTags, title: pageTitle },
-        getSettings,
-        rootPath = '',
-      },
-    } = this.props
-    const settings = getSettings(APP_LOCATOR) || {}
-    const {
-      titleTag,
-      metaTagDescription,
-      metaTagRobots,
-      storeName,
-      faviconLinks,
-    } = settings
+  const settings = getSettings(APP_LOCATOR) || {}
+  const {
+    titleTag,
+    metaTagDescription,
+    metaTagRobots,
+    storeName,
+    faviconLinks,
+  } = settings
 
-    const { canonicalHost, canonicalPath } = systemToCanonical(route)
-    const description = (metaTags && metaTags.description) || metaTagDescription
-    const title = pageTitle || titleTag
+  const { canonicalHost, canonicalPath } = systemToCanonical(route)
+  const description = (metaTags && metaTags.description) || metaTagDescription
+  const title = pageTitle || titleTag
 
-    const [queryMatch] = route.path.match(/\?.*/) || ['?']
+  const [queryMatch] = route.path.match(/\?.*/) || ['?']
 
-    const canonicalLink =
-      canonicalHost &&
-      canonicalPath &&
-      `https://${canonicalHost}${rootPath}${
-        canonicalPath ? canonicalPath.toLowerCase() : ''
-      }`
+  const canonicalLink =
+    canonicalHost &&
+    canonicalPath &&
+    `https://${canonicalHost}${rootPath}${
+      canonicalPath ? canonicalPath.toLowerCase() : ''
+    }`
 
-    return (
-      <Fragment>
-        <Helmet
-          title={title}
-          meta={[
-            // viewport meta tag is already handled in render-server for AMP pages
-            !amp && { name: 'viewport', content: MOBILE_SCALING },
-            { name: 'description', content: description },
-            { name: 'copyright', content: storeName },
-            { name: 'author', content: storeName },
-            { name: 'country', content: country },
-            { name: 'language', content: locale },
-            { name: 'currency', content: currency },
-            { name: 'robots', content: metaTagRobots || META_ROBOTS },
-            { httpEquiv: 'Content-Type', content: CONTENT_TYPE },
-          ]
-            .filter(Boolean)
-            .filter(meta => meta.content && meta.content.length > 0)}
-          script={[
-            {
-              type: 'text/javascript',
-              src: `${rootPath}/pwa/workers/register.js${queryMatch}&scope=${encodeURIComponent(
-                rootPath
-              )}`,
-              defer: true,
-            },
-          ]}
-          link={[
-            ...(faviconLinks || []),
-            ...(!amp && canonicalLink
-              ? [
-                  /*{
+  return (
+    <Fragment>
+      <Helmet
+        title={title}
+        meta={[
+          // viewport meta tag is already handled in render-server for AMP pages
+          !amp && { name: 'viewport', content: MOBILE_SCALING },
+          { name: 'description', content: description },
+          { name: 'copyright', content: storeName },
+          { name: 'author', content: storeName },
+          { name: 'country', content: country },
+          { name: 'language', content: locale },
+          { name: 'currency', content: currency },
+          { name: 'robots', content: metaTagRobots || META_ROBOTS },
+          { httpEquiv: 'Content-Type', content: CONTENT_TYPE },
+        ]
+          .filter(Boolean)
+          .filter(meta => meta.content && meta.content.length > 0)}
+        script={[
+          supportsServiceWorker && {
+            type: 'text/javascript',
+            src: `${rootPath}/pwa/workers/register.js${queryMatch}&scope=${encodeURIComponent(
+              rootPath
+            )}`,
+            defer: true,
+          },
+        ].filter(Boolean)}
+        link={[
+          ...(faviconLinks || []),
+          ...(!amp && canonicalLink
+            ? [
+                /*{
                     rel: 'amphtml',
                     href: encodeURI(`${canonicalLink}?amp`),
                   },*/
-                  {
-                    rel: 'canonical',
-                    href: encodeURI(canonicalLink),
-                  },
-                ]
-              : []),
-          ].filter(Boolean)}
-        />
-        <PixelProvider currency={currency}>
-          <PWAProvider rootPath={rootPath}>
-            <PageViewPixel title={title} />
-            <ToastProvider positioning="window">
-              <NetworkStatusToast />
-              <OrderFormProvider>
-                <OrderQueueProvider>
-                  <OrderFormProviderCheckout>
-                    <WrapperContainer className="vtex-store__template bg-base">
-                      {this.props.children}
-                    </WrapperContainer>
-                  </OrderFormProviderCheckout>
-                </OrderQueueProvider>
-              </OrderFormProvider>
-            </ToastProvider>
-          </PWAProvider>
-        </PixelProvider>
-        {this.isStorefrontIframe && (
-          <NoSSR>
-            <ExtensionPoint id="highlight-overlay" />
-          </NoSSR>
-        )}
-      </Fragment>
-    )
-  }
+                {
+                  rel: 'canonical',
+                  href: encodeURI(canonicalLink),
+                },
+              ]
+            : []),
+        ].filter(Boolean)}
+      />
+      <PixelProvider currency={currency}>
+        <PWAProvider rootPath={rootPath}>
+          <PageViewPixel title={title} />
+          <ToastProvider positioning="window">
+            <NetworkStatusToast />
+            <OrderFormProvider>
+              <OrderQueueProvider>
+                <OrderFormProviderCheckout>
+                  <WrapperContainer className="vtex-store__template bg-base">
+                    {children}
+                  </WrapperContainer>
+                </OrderFormProviderCheckout>
+              </OrderQueueProvider>
+            </OrderFormProvider>
+          </ToastProvider>
+        </PWAProvider>
+      </PixelProvider>
+      {isStorefrontIframe && (
+        <NoSSR>
+          <ExtensionPoint id="highlight-overlay" />
+        </NoSSR>
+      )}
+    </Fragment>
+  )
 }
 
-export default withRuntimeContext(StoreWrapper)
+StoreWrapper.propTypes = {
+  children: PropTypes.element,
+}
+
+export default StoreWrapper


### PR DESCRIPTION
#### What is the purpose of this pull request?
Check for service worker support in the current browser _before_ adding the script to register the service worker to the page. This will also change the server-side rendering behaviour, so the script can only be added in the client-side now.

#### What problem is this solving?
Browsers that do not have the service worker capabilities won't benefit from downloading this script at all, so it's just wasted network resource at this point. Also, they may throw a syntax error for some ES6 features we are using (such as arrow functions, and `const` and `let` declarations), and this will prevent just that.

#### How should this be manually tested?
You can access the changes in [this workspace](https://lucas2--storecomponents.myvtex.com/)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
