### PR TITLE
Add add-to-cart-button to allowed list for store.product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `add-to-cart` button to allowed list for `store.product`.
 
 ## [2.75.1] - 2019-11-19
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -59,7 +59,8 @@
     "vtex.pwa-components": "0.x",
     "vtex.list-context": "0.x",
     "vtex.menu": "2.x",
-    "vtex.order-manager": "0.x"
+    "vtex.order-manager": "0.x",
+    "vtex.add-to-cart-button": "0.x"
   },
   "settingsSchema": {
     "title": "VTEX Store",
@@ -113,10 +114,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "Configure your store's favicons"
       }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -60,6 +60,7 @@
       "product-price",
       "sku-selector",
       "buy-button",
+      "add-to-cart-button",
       "product-separator",
       "product-description",
       "product-specifications",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `add-to-cart-button` to the allowed list for `store.product` interface.

#### What problem is this solving?

This enables the `add-to-cart-button` block to be used inside of a PDP.

#### How should this be manually tested?

[Workspace](https://minicart--storecomponents.myvtex.com/classic-shoes/p)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
