### PR TITLE
Navigation path normalisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Navigation normalisation with path.toLowerCase and sort of specificationFilters
 
 ## [2.78.1] - 2019-12-11
 ### Added

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -17,82 +17,12 @@ import PageViewPixel from './components/PageViewPixel'
 import OrderFormProvider from './components/OrderFormProvider'
 import NetworkStatusToast from './components/NetworkStatusToast'
 import WrapperContainer from './components/WrapperContainer'
-
-import { contains, map, path as ramdaPath, uniq, zip } from 'ramda'
-import queryString from 'query-string'
+import normalizeNavigation from './utils/navigation'
 
 const APP_LOCATOR = 'vtex.store'
 const CONTENT_TYPE = 'text/html; charset=utf-8'
 const META_ROBOTS = 'index, follow'
 const MOBILE_SCALING = 'width=device-width, initial-scale=1'
-const CATEGORY_TREE_MAX_DEPTH = 5
-
-const normalizeQueryMap = (categoryTreeDepth, queryMap) => {
-  const splitMap = queryMap.map && queryMap.map.split(',')
-  const splitQuery = queryMap.query && queryMap.query.split('/').slice(1)
-  const zippedMapQuery = zip(splitMap, splitQuery)
-
-  const sorted =
-    zippedMapQuery &&
-    zippedMapQuery.slice(categoryTreeDepth).sort((tuple1, tuple2) => {
-      const [, specFilterVal1] = tuple1[0].split('specificationFilter_')
-      const [, specFilterVal2] = tuple2[0].split('specificationFilter_')
-      const facetName1 = tuple1[1]
-      const facetName2 = tuple2[1]
-      return (
-        Number(specFilterVal1) -
-        Number(specFilterVal2) +
-        facetName1.localeCompare(facetName2)
-      )
-    })
-
-  const assembledSortedQuery = [
-    ...zippedMapQuery.slice(0, categoryTreeDepth),
-    ...uniq(sorted),
-  ]
-
-  queryMap.map = assembledSortedQuery.map(tuple => tuple[0]).join(',')
-  queryMap.query = `/${assembledSortedQuery.map(tuple => tuple[1]).join('/')}`
-}
-
-export const normalizeNavigation = navigation => {
-  const { path, query } = navigation
-  if (ramdaPath(['__RUNTIME__', 'route', 'domain'], window) !== 'store') {
-    return navigation
-  }
-
-  const queryMap = query ? queryString.parse(query) : {}
-  if (queryMap && queryMap.map) {
-    const pathSegments = path.startsWith('/')
-      ? path.split('/').slice(1)
-      : path.split('/')
-    const mapValues = queryMap.map.split(',').slice(0, pathSegments.length)
-    const convertedSegments = map(
-      ([pathSegment, mapValue]) =>
-        contains('specificationFilter', mapValue)
-          ? pathSegment
-          : pathSegment.toLowerCase(),
-      zip(pathSegments, mapValues)
-    )
-    const categoryTreeDepth = Math.min(
-      convertedSegments.length,
-      CATEGORY_TREE_MAX_DEPTH
-    )
-
-    normalizeQueryMap(categoryTreeDepth, queryMap)
-    navigation.query = queryString.stringify(queryMap, {
-      encode: false,
-    })
-
-    navigation.path = path.startsWith('/')
-      ? `/${convertedSegments.join('/')}`
-      : convertedSegments.join('/')
-    return navigation
-  }
-
-  navigation.path = navigation.path && navigation.path.toLowerCase()
-  return navigation
-}
 
 const systemToCanonical = ({ canonicalPath }) => {
   const canonicalHost =

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -86,9 +86,7 @@ const StoreWrapper = ({ children }) => {
   const canonicalLink =
     canonicalHost &&
     canonicalPath &&
-    `https://${canonicalHost}${rootPath}${
-      canonicalPath ? canonicalPath.toLowerCase() : ''
-    }`
+    `https://${canonicalHost}${rootPath}${canonicalPath}`
 
   return (
     <Fragment>

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -18,10 +18,81 @@ import OrderFormProvider from './components/OrderFormProvider'
 import NetworkStatusToast from './components/NetworkStatusToast'
 import WrapperContainer from './components/WrapperContainer'
 
+import { contains, map, path as ramdaPath, uniq, zip } from 'ramda'
+import queryString from 'query-string'
+
 const APP_LOCATOR = 'vtex.store'
 const CONTENT_TYPE = 'text/html; charset=utf-8'
 const META_ROBOTS = 'index, follow'
 const MOBILE_SCALING = 'width=device-width, initial-scale=1'
+const CATEGORY_TREE_MAX_DEPTH = 3
+
+const normalizeQueryMap = (categoryTreeDepth, queryMap) => {
+  const splitMap = queryMap.map && queryMap.map.split(',')
+  const splitQuery = queryMap.query && queryMap.query.split('/').slice(1)
+  const zippedMapQuery = zip(splitMap, splitQuery)
+
+  const sorted =
+    zippedMapQuery &&
+    zippedMapQuery.slice(categoryTreeDepth).sort((tuple1, tuple2) => {
+      const [, specFilterVal1] = tuple1[0].split('specificationFilter_')
+      const [, specFilterVal2] = tuple2[0].split('specificationFilter_')
+      const facetName1 = tuple1[1]
+      const facetName2 = tuple2[1]
+      return (
+        Number(specFilterVal1) -
+        Number(specFilterVal2) +
+        facetName1.localeCompare(facetName2)
+      )
+    })
+
+  const assembledSortedQuery = [
+    ...zippedMapQuery.slice(0, categoryTreeDepth),
+    ...uniq(sorted),
+  ]
+
+  queryMap.map = assembledSortedQuery.map(tuple => tuple[0]).join(',')
+  queryMap.query = `/${assembledSortedQuery.map(tuple => tuple[1]).join('/')}`
+}
+
+export const normalizeNavigation = navigation => {
+  const { path, query } = navigation
+  if (ramdaPath(['__RUNTIME__', 'route', 'domain'], window) !== 'store') {
+    return navigation
+  }
+
+  const queryMap = query ? queryString.parse(query) : {}
+  if (queryMap && queryMap.map) {
+    const pathSegments = path.startsWith('/')
+      ? path.split('/').slice(1)
+      : path.split('/')
+    const mapValues = queryMap.map.split(',').slice(0, pathSegments.length)
+    const convertedSegments = map(
+      ([pathSegment, mapValue]) =>
+        contains('specificationFilter', mapValue)
+          ? pathSegment
+          : pathSegment.toLowerCase(),
+      zip(pathSegments, mapValues)
+    )
+    const categoryTreeDepth = Math.min(
+      convertedSegments.length,
+      CATEGORY_TREE_MAX_DEPTH
+    )
+
+    normalizeQueryMap(categoryTreeDepth, queryMap)
+    navigation.query = queryString.stringify(queryMap, {
+      encode: false,
+    })
+
+    navigation.path = path.startsWith('/')
+      ? `/${convertedSegments.join('/')}`
+      : convertedSegments.join('/')
+    return navigation
+  }
+
+  navigation.path = navigation.path && navigation.path.toLowerCase()
+  return navigation
+}
 
 const systemToCanonical = ({ canonicalPath }) => {
   const canonicalHost =
@@ -41,8 +112,8 @@ const StoreWrapper = ({ children }) => {
     getSettings,
     rootPath = '',
     prefetchDefaultPages,
+    addNavigationRouteModifier,
   } = useRuntime()
-
   const isStorefrontIframe =
     canUseDOM && window.top !== window.self && window.top.__provideRuntime
 
@@ -62,6 +133,10 @@ const StoreWrapper = ({ children }) => {
       'store.search#subcategory-terms',
     ])
   }, [prefetchDefaultPages])
+
+  useEffect(() => {
+    addNavigationRouteModifier(normalizeNavigation)
+  }, [addNavigationRouteModifier])
 
   const settings = getSettings(APP_LOCATOR) || {}
   const {

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -17,7 +17,7 @@ import PageViewPixel from './components/PageViewPixel'
 import OrderFormProvider from './components/OrderFormProvider'
 import NetworkStatusToast from './components/NetworkStatusToast'
 import WrapperContainer from './components/WrapperContainer'
-import normalizeNavigation from './utils/navigation'
+import { normalizeNavigation } from './utils/navigation'
 
 const APP_LOCATOR = 'vtex.store'
 const CONTENT_TYPE = 'text/html; charset=utf-8'

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -25,7 +25,7 @@ const APP_LOCATOR = 'vtex.store'
 const CONTENT_TYPE = 'text/html; charset=utf-8'
 const META_ROBOTS = 'index, follow'
 const MOBILE_SCALING = 'width=device-width, initial-scale=1'
-const CATEGORY_TREE_MAX_DEPTH = 3
+const CATEGORY_TREE_MAX_DEPTH = 5
 
 const normalizeQueryMap = (categoryTreeDepth, queryMap) => {
   const splitMap = queryMap.map && queryMap.map.split(',')

--- a/react/__tests__/navigation.test.js
+++ b/react/__tests__/navigation.test.js
@@ -1,0 +1,31 @@
+import { normalizeNavigation } from '../utils/navigation'
+
+describe('Navigation route modifier', () => {
+  window['__RUNTIME__'] = {
+    route: {
+      domain: 'store',
+    },
+  }
+
+  it('should lowercase the path', () => {
+    const path = '/Category1/category2/Category3'
+    const query =
+      'map=c,c,c,specificationFilter_1&query=/Category1/category2/Category3/xpto'
+    const expectedPath = path.toLocaleLowerCase()
+    const expectedQuery = query
+    const result = normalizeNavigation({ path, query })
+
+    expect(result).toEqual({ path: expectedPath, query: expectedQuery })
+  })
+  it('should sort specification filters', () => {
+    const path = '/Category1/category2/Category3'
+    const query =
+      'map=c,c,c,specificationFilter_2,specificationFilter_0,specificationFilter_1&query=/Category1/category2/Category3/xpto2/xpto0/xpto1'
+    const expectedPath = path.toLocaleLowerCase()
+    const expectedQuery =
+      'map=c,c,c,specificationFilter_0,specificationFilter_1,specificationFilter_2&query=/Category1/category2/Category3/xpto0/xpto1/xpto2'
+    const result = normalizeNavigation({ path, query })
+
+    expect(result).toEqual({ path: expectedPath, query: expectedQuery })
+  })
+})

--- a/react/package.json
+++ b/react/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.5.10",
-    "ramda": "^0.26.1"
+    "ramda": "^0.26.1",
+    "query-string": "^6.9.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -1,0 +1,71 @@
+import { contains, map, path as ramdaPath, uniq, zip } from 'ramda'
+import queryString from 'query-string'
+
+const CATEGORY_TREE_MAX_DEPTH = 5
+
+const normalizeQueryMap = (categoryTreeDepth, queryMap) => {
+  const splitMap = queryMap.map && queryMap.map.split(',')
+  const splitQuery = queryMap.query && queryMap.query.split('/').slice(1)
+  const zippedMapQuery = zip(splitMap, splitQuery)
+
+  const sorted =
+    zippedMapQuery &&
+    zippedMapQuery.slice(categoryTreeDepth).sort((tuple1, tuple2) => {
+      const [, specFilterVal1] = tuple1[0].split('specificationFilter_')
+      const [, specFilterVal2] = tuple2[0].split('specificationFilter_')
+      const facetName1 = tuple1[1]
+      const facetName2 = tuple2[1]
+      return (
+        Number(specFilterVal1) -
+        Number(specFilterVal2) +
+        facetName1.localeCompare(facetName2)
+      )
+    })
+
+  const assembledSortedQuery = [
+    ...zippedMapQuery.slice(0, categoryTreeDepth),
+    ...uniq(sorted),
+  ]
+
+  queryMap.map = assembledSortedQuery.map(tuple => tuple[0]).join(',')
+  queryMap.query = `/${assembledSortedQuery.map(tuple => tuple[1]).join('/')}`
+}
+
+export const normalizeNavigation = navigation => {
+  const { path, query } = navigation
+  if (ramdaPath(['__RUNTIME__', 'route', 'domain'], window) !== 'store') {
+    return navigation
+  }
+
+  const queryMap = query ? queryString.parse(query) : {}
+  if (queryMap && queryMap.map) {
+    const pathSegments = path.startsWith('/')
+      ? path.split('/').slice(1)
+      : path.split('/')
+    const mapValues = queryMap.map.split(',').slice(0, pathSegments.length)
+    const convertedSegments = map(
+      ([pathSegment, mapValue]) =>
+        contains('specificationFilter', mapValue)
+          ? pathSegment
+          : pathSegment.toLowerCase(),
+      zip(pathSegments, mapValues)
+    )
+    const categoryTreeDepth = Math.min(
+      convertedSegments.length,
+      CATEGORY_TREE_MAX_DEPTH
+    )
+
+    normalizeQueryMap(categoryTreeDepth, queryMap)
+    navigation.query = queryString.stringify(queryMap, {
+      encode: false,
+    })
+
+    navigation.path = path.startsWith('/')
+      ? `/${convertedSegments.join('/')}`
+      : convertedSegments.join('/')
+    return navigation
+  }
+
+  navigation.path = navigation.path && navigation.path.toLowerCase()
+  return navigation
+}

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -25,7 +25,8 @@ const queryMapComparator = (tuple1, tuple2) => {
 const normalizeQueryMap = (categoryTreeDepth, queryMap) => {
   const splitMap = queryMap.map && queryMap.map.split(',')
   const splitQuery = queryMap.query && queryMap.query.split('/').slice(1)
-  const zippedMapQuery = zip(splitMap, splitQuery)
+  const zippedMapQuery =
+    splitMap && splitQuery ? zip(splitMap, splitQuery) : splitMap
 
   const sorted =
     zippedMapQuery &&
@@ -36,8 +37,13 @@ const normalizeQueryMap = (categoryTreeDepth, queryMap) => {
     ...uniq(sorted),
   ]
 
-  queryMap.map = assembledSortedQuery.map(tuple => tuple[0]).join(',')
-  queryMap.query = `/${assembledSortedQuery.map(tuple => tuple[1]).join('/')}`
+  queryMap.map =
+    splitMap &&
+    assembledSortedQuery
+      .map(value => (Array.isArray(value) ? value[0] : value))
+      .join(',')
+  queryMap.query =
+    splitQuery && `/${assembledSortedQuery.map(tuple => tuple[1]).join('/')}`
 }
 
 export const normalizeNavigation = navigation => {

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -3,6 +3,25 @@ import queryString from 'query-string'
 
 const CATEGORY_TREE_MAX_DEPTH = 5
 
+const queryMapComparator = (tuple1, tuple2) => {
+  const [, specFilterVal1] = tuple1[0].split('specificationFilter_')
+  const [, specFilterVal2] = tuple2[0].split('specificationFilter_')
+  const facetName1 = tuple1[1]
+  const facetName2 = tuple2[1]
+
+  const considerSpecificationFilter =
+    specFilterVal1 &&
+    specFilterVal2 &&
+    !isNaN(Number(specFilterVal1)) &&
+    !isNaN(Number(specFilterVal2))
+
+  return considerSpecificationFilter
+    ? Number(specFilterVal1) -
+        Number(specFilterVal2) +
+        facetName1.localeCompare(facetName2)
+    : facetName1.localeCompare(facetName2)
+}
+
 const normalizeQueryMap = (categoryTreeDepth, queryMap) => {
   const splitMap = queryMap.map && queryMap.map.split(',')
   const splitQuery = queryMap.query && queryMap.query.split('/').slice(1)
@@ -10,17 +29,7 @@ const normalizeQueryMap = (categoryTreeDepth, queryMap) => {
 
   const sorted =
     zippedMapQuery &&
-    zippedMapQuery.slice(categoryTreeDepth).sort((tuple1, tuple2) => {
-      const [, specFilterVal1] = tuple1[0].split('specificationFilter_')
-      const [, specFilterVal2] = tuple2[0].split('specificationFilter_')
-      const facetName1 = tuple1[1]
-      const facetName2 = tuple2[1]
-      return (
-        Number(specFilterVal1) -
-        Number(specFilterVal2) +
-        facetName1.localeCompare(facetName2)
-      )
-    })
+    zippedMapQuery.slice(categoryTreeDepth).sort(queryMapComparator)
 
   const assembledSortedQuery = [
     ...zippedMapQuery.slice(0, categoryTreeDepth),

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -1,7 +1,16 @@
 import { contains, map, path as ramdaPath, uniq, zip } from 'ramda'
 import queryString from 'query-string'
 
-const CATEGORY_TREE_MAX_DEPTH = 5
+const categoriesInSequence = mapValues => {
+  let count = 0
+  for (const value of mapValues) {
+    if (value !== 'c') {
+      return count
+    }
+    count++
+  }
+  return count
+}
 
 const queryMapComparator = (tuple1, tuple2) => {
   const [, specFilterVal1] = tuple1 && tuple1[0].split('specificationFilter_')
@@ -23,15 +32,12 @@ const queryMapComparator = (tuple1, tuple2) => {
 }
 
 const normalizeQueryMap = (path, queryMap) => {
-  const splitMap = queryMap.map && queryMap.map.split(',')
+  const splitMap = queryMap.map.split(',')
   const splitQuery = queryMap.query
     ? queryMap.query.split('/').slice(1)
     : path.split('/')
 
-  const categoryTreeDepth = Math.min(
-    path.split('/').length,
-    CATEGORY_TREE_MAX_DEPTH
-  )
+  const categoryTreeDepth = categoriesInSequence(splitMap)
   const zippedMapQuery = zip(splitMap, splitQuery)
 
   const sorted =
@@ -61,7 +67,7 @@ export const normalizeNavigation = navigation => {
   }
 
   const queryMap = query ? queryString.parse(query) : {}
-  if (queryMap && queryMap.map) {
+  if (queryMap.map) {
     const pathSegments = path.startsWith('/')
       ? path.split('/').slice(1)
       : path.split('/')

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4298,6 +4298,15 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.9.0.tgz#1c3b727c370cf00f177c99f328fda2108f8fa3dd"
+  integrity sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 ramda@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
@@ -4857,6 +4866,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -4901,6 +4915,11 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add navigation normalisation with `path.toLowerCase` and sort of `specificationFilters`
Merge after: [https://github.com/vtex-apps/render-runtime/pull/455](url)

<!--- Describe your changes in detail. -->

#### What problem is this solving?
This logic was implemented in render runtime. It makes sense to be here since it's a logic specific to stores.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
1 - open: https://jey--alssports.myvtex.com
2 - navigate to any category on the menu
3 - select any filter at the sidebar
4 - check the url, specificationFilters should be sorted and path should be lowercase

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
