### PR TITLE
Fix hanging loading screen between loading pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Hanging loading screen between search pages.
 
 ## [2.77.0] - 2019-12-03
 ### Removed

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -100,7 +100,7 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
   } = props
   const { account, getSettings } = useRuntime()
   const settings = getSettings(APP_LOCATOR) || {}
-  const loading = searchQuery.loading
+  const loading = searchQuery ? searchQuery.loading : undefined
   const { titleTag: defaultStoreTitle, storeName } = settings
   const title = getTitleTag(
     titleTag,

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -94,13 +94,13 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
     params,
     searchQuery,
     searchQuery: {
-      loading = true,
       data: { searchMetadata: { titleTag = '', metaTagDescription = '' } = {} } = {},
     } = {},
     children,
   } = props
   const { account, getSettings } = useRuntime()
   const settings = getSettings(APP_LOCATOR) || {}
+  const loading = searchQuery.loading
   const { titleTag: defaultStoreTitle, storeName } = settings
   const title = getTitleTag(
     titleTag,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix bug of hanging loading between search page transitions.

#### What problem is this solving?

Fix the last version of vtex.store.

#### How should this be manually tested?

Before:
1. Open https://brenobug--exitocol.myvtex.com/
2. Click in Mercado, page loads properly
3. Hover Mercado and click in "Salsas Condimentos y Sopas"
4. Should show a hanging loading state

Fixed:
1. Open https://breno--exitocol.myvtex.com/
2. Click in Mercado, page loads properly
3. Hover Mercado and click in "Salsas Condimentos y Sopas"
4. Page should load properly

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
