### PR TITLE
Fix/remove square

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- ProductContext loading prop is only set true while the main product quuery is being done.
 
 ## [2.79.1] - 2019-12-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- ProductContext loading prop is only set true while the main product quuery is being done.
+- ProductContext loading prop is only set true while the main product query is not done.
 
 ## [2.79.1] - 2019-12-16
 ### Fixed

--- a/react/ProductContext.js
+++ b/react/ProductContext.js
@@ -40,9 +40,8 @@ const useProduct = ({ catalog, productBenefits, categoryTree }) => {
 function getLoading(props) {
   const {
     catalog: { loading: catalogLoading = true } = {},
-    productBenefits: { loading: benefitsLoading = true } = {},
   } = props
-  return catalogLoading || benefitsLoading
+  return catalogLoading
 }
 
 function useNotFound(loading, propsProduct, slug) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Only the product query is done in the render-server, so in order to never show the grey square, the loading prop should be only the main product query, and not with the benefits query.

https://wfbeta--boticario.myvtex.com/
https://wfbeta--alssports.myvtex.com/
https://wfbeta--exitocol.myvtex.com/
https://wfbeta--tbb.myvtex.com/
https://wfbeta--paguemenos.myvtex.com/
https://wfbeta--samsungar.myvtex.com/

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
