### PR TITLE
Adds *terms to subcategory canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adds `/*terms` to subcategory canonical
 
 ## [2.85.2] - 2020-01-28
 ### Changed

--- a/store/routes.json
+++ b/store/routes.json
@@ -37,7 +37,7 @@
   },
   "store.search#subcategory": {
     "path": "/_v/segment/routing/vtex.store@2.x/subcategory/:id/:department/:category/:subcategory(/*terms)",
-    "canonical": "/:department/:category/:subcategory",
+    "canonical": "/:department/:category/:subcategory(/*terms)",
     "map": ["c", "c", "c"],
     "contentType": "subcategory"
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

#### What problem is this solving?

Since we can have more than 3 categories, the subcategory canonical path should reflect that.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
