### PR TITLE
New search urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Separate URL normalization on navigate for new and legacy search URLs
 
 ## [2.86.0] - 2020-02-06 [YANKED]
 ### Added

--- a/react/__tests__/navigation.test.js
+++ b/react/__tests__/navigation.test.js
@@ -28,4 +28,11 @@ describe('Navigation route modifier', () => {
 
     expect(result).toEqual({ path: expectedPath, query: expectedQuery })
   })
+  it('should preserve case for new routes pattern', () => {
+    const path = '/foo/Bar/nice_Bar'
+    const expectedPath = '/foo/bar/nice_Bar'
+    const ignore = { 'nice-bar': { path: 'nice_Bar' } }
+    const result = normalizeNavigation({ path, ignore })
+    expect(result).toEqual({ path: expectedPath, ignore, query: undefined })
+  })
 })

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -6,8 +6,7 @@ const MAP_CATEGORY_CHAR = 'c'
 const MAP_VALUES_SEP = ','
 const PATH_SEPARATOR = '/'
 
-const isLegacySearchFormat = (pathSegments, queryMap) => {
-  const { map } = queryMap
+const isLegacySearchFormat = (pathSegments, map) => {
   if (!map) {
     return false
   }

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -1,10 +1,26 @@
-import { contains, map, path as ramdaPath, uniq, zip } from 'ramda'
+import { contains, path as ramdaPath, uniq, zip, flatten } from 'ramda'
 import queryString from 'query-string'
+
+const SPEC_FILTER = 'specificationFilter'
+const MAP_CATEGORY_CHAR = 'c'
+const MAP_VALUES_SEP = ','
+const PATH_SEPARATOR = '/'
+
+const isLegacySearchFormat = (pathSegments, queryMap) => {
+  const { map } = queryMap
+  if (!map) {
+    return false
+  }
+  return (
+    map.includes(SPEC_FILTER) ||
+    map.split(MAP_VALUES_SEP).length === pathSegments.length
+  )
+}
 
 const categoriesInSequence = mapValues => {
   let count = 0
   for (const value of mapValues) {
-    if (value !== 'c') {
+    if (value !== MAP_CATEGORY_CHAR) {
       return count
     }
     count++
@@ -13,8 +29,8 @@ const categoriesInSequence = mapValues => {
 }
 
 const queryMapComparator = (tuple1, tuple2) => {
-  const [, specFilterVal1] = tuple1 && tuple1[0].split('specificationFilter_')
-  const [, specFilterVal2] = tuple2 && tuple2[0].split('specificationFilter_')
+  const [, specFilterVal1] = tuple1 && tuple1[0].split(`${SPEC_FILTER}_`)
+  const [, specFilterVal2] = tuple2 && tuple2[0].split(`${SPEC_FILTER}_`)
   const facetName1 = tuple1[1]
   const facetName2 = tuple2[1]
 
@@ -31,77 +47,95 @@ const queryMapComparator = (tuple1, tuple2) => {
     : facetName1.localeCompare(facetName2)
 }
 
-const normalizeQueryMap = (path, queryMap) => {
-  const splitMap = queryMap.map.split(',')
-  const splitQuery = queryMap.query
-    ? queryMap.query.split('/').slice(1)
-    : path.split('/')
-
-  const categoryTreeDepth = categoriesInSequence(splitMap)
-  const zippedMapQuery = zip(splitMap, splitQuery)
+const normalizeQueryMap = (pathSegments, mapSegments) => {
+  const categoryTreeDepth = categoriesInSequence(mapSegments)
+  const zippedMapQuery = zip(mapSegments, pathSegments)
 
   const sorted =
     zippedMapQuery &&
     zippedMapQuery.slice(categoryTreeDepth).sort(queryMapComparator)
 
-  const assembledSortedQuery = [
-    ...zippedMapQuery.slice(0, categoryTreeDepth),
-    ...uniq(sorted),
-  ]
+  const assembledSortedQuery = zippedMapQuery
+    .slice(0, categoryTreeDepth)
+    .concat(sorted)
 
-  const sortedQueryMap = assembledSortedQuery
+  const sortedMap = assembledSortedQuery
     .map(value => (Array.isArray(value) ? value[0] : value))
     .join(',')
-  const sortedQueryPath = assembledSortedQuery.map(tuple => tuple[1]).join('/')
+  const sortedPathSegments = assembledSortedQuery.map(tuple => tuple[1])
 
   return {
-    map: sortedQueryMap,
-    path: sortedQueryPath,
+    map: sortedMap,
+    pathSegments: sortedPathSegments,
   }
 }
 
+const normalizeSearchNavigation = (pathSegments, map, segmentsToIgnore) => {
+  const normalizedSegments = pathSegments.map(segment =>
+    segmentsToIgnore.includes(segment) ? segment : segment.toLowerCase()
+  )
+  return { pathSegments: normalizedSegments, map }
+}
+
+const getIgnoredSegments = ignore => {
+  return ignore
+    ? flatten(
+        Object.values(ignore).map(routeModifier =>
+          routeModifier.path.split(PATH_SEPARATOR)
+        )
+      )
+    : []
+}
+
+const normalizeLegacySearchNavigation = (pathSegments, queryMap, query) => {
+  const { map } = queryMap
+  if (map) {
+    const mapValues = map.split(MAP_VALUES_SEP)
+    let convertedSegments = map(
+      ([pathSegment, mapValue]) =>
+        contains(SPEC_FILTER, mapValue)
+          ? pathSegment
+          : pathSegment.toLowerCase(),
+      zip(pathSegments, mapValues)
+    )
+
+    const {
+      pathSegments: sortedPathSegments,
+      map: sortedMap,
+    } = normalizeQueryMap(convertedSegments, map)
+    queryMap.map = sortedMap
+
+    const normalizedQuery = queryString.stringify(queryMap, {
+      encode: false,
+    })
+
+    return { pathSegments: sortedPathSegments, query: normalizedQuery }
+  }
+  return { pathSegments: pathSegments, query: query }
+}
+
 export const normalizeNavigation = navigation => {
-  const { path, query } = navigation
   if (ramdaPath(['__RUNTIME__', 'route', 'domain'], window) !== 'store') {
     return navigation
   }
 
-  const queryMap = query ? queryString.parse(query) : {}
-  if (queryMap.map) {
-    const pathSegments = path.startsWith('/')
-      ? path.split('/').slice(1)
-      : path.split('/')
-    const mapValues = queryMap.map.split(',').slice(0, pathSegments.length)
-    let convertedSegments = map(
-      ([pathSegment, mapValue]) =>
-        contains('specificationFilter', mapValue)
-          ? pathSegment
-          : pathSegment.toLowerCase(),
-      zip(pathSegments, mapValues)
-    ).join('/')
+  const { path, query, ignore } = navigation
+  const parsedQuery = query ? queryString.parse(query) : {}
+  const { map } = parsedQuery
 
-    const { map: sortedMap, path: sortedPath } = normalizeQueryMap(
-      convertedSegments,
-      queryMap
-    )
+  const pathSegments = path.startsWith(PATH_SEPARATOR)
+    ? path.split(PATH_SEPARATOR).slice(1)
+    : path.split(PATH_SEPARATOR)
 
-    if (queryMap.query) {
-      queryMap.query = `/${sortedPath}`
-    } else {
-      convertedSegments = sortedPath
-    }
+  const segmentsToIgnore = getIgnoredSegments(ignore)
 
-    queryMap.map = sortedMap
-    navigation.query = queryString.stringify(queryMap, {
-      encode: false,
-    })
+  const normalizedNavigation = isLegacySearchFormat(pathSegments, map)
+    ? normalizeLegacySearchNavigation(pathSegments, map, query)
+    : normalizeSearchNavigation(pathSegments, query, segmentsToIgnore)
 
-    navigation.path = path.startsWith('/')
-      ? `/${convertedSegments}`
-      : convertedSegments
-    return navigation
-  }
-
-  navigation.path = navigation.path && navigation.path.toLowerCase()
+  navigation.path = path.startsWith('/')
+    ? '/' + normalizedNavigation.pathSegments.join('/')
+    : normalizedNavigation.pathSegments.join('/')
+  navigation.query = normalizedNavigation.query
   return navigation
 }

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -1,4 +1,4 @@
-import { contains, path as ramdaPath, uniq, zip, flatten } from 'ramda'
+import { contains, path as ramdaPath, zip, flatten } from 'ramda'
 import queryString from 'query-string'
 
 const SPEC_FILTER = 'specificationFilter'

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -125,7 +125,7 @@ export const normalizeNavigation = navigation => {
     return navigation
   }
 
-  const { path, query, ignore } = navigation
+  const { path, query, options } = navigation
   const parsedQuery = query ? queryString.parse(query) : {}
   const { map } = parsedQuery
 
@@ -133,7 +133,7 @@ export const normalizeNavigation = navigation => {
     ? path.split(PATH_SEPARATOR).slice(1)
     : path.split(PATH_SEPARATOR)
 
-  const segmentsToIgnore = getIgnoredSegments(ignore)
+  const segmentsToIgnore = getIgnoredSegments(options)
 
   const normalizedNavigation =
     parsedQuery.query || isLegacySearchFormat(pathSegments, map)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Separate URL normalization on navigate for new and legacy search URLs

<!--- Describe your changes in detail. -->
The idea here is to maintain compatibility between our current search URL structure `/foo/Bar?map=c,specificationFilter_1` and our new one `/foo/nice_Bar`. 

At the current URL structure we apply a lowerCase function whenever the segment is nos a specificationFilter and we also sort everything that's not category.

At our new URL structure we keep lowerCasing stuff, but there are segments we wan't to keep static, soo we've added, getIgnoredSegments, this happens with the specFilter, `/foo/nice_Bar`, case where we should maintain it's case.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
