### PR TITLE
Added `imagePerSKUQuantity` on `ProductContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `imagePerSKUQuantity` on `ProductContext`.
+- `imageQuantity` on `ProductContext`.
 
 ## [2.87.2] - 2020-02-11 [YANKED]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `imagePerSKUQuantity` on `ProductContext`.
 
 ## [2.87.2] - 2020-02-11 [YANKED]
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -116,7 +116,10 @@
               "type": "string"
             }
           },
-          "required": ["rel", "href"]
+          "required": [
+            "rel",
+            "href"
+          ]
         },
         "description": "Configure your store's favicons"
       }

--- a/react/ProductContext.js
+++ b/react/ProductContext.js
@@ -126,7 +126,7 @@ const catalogOptions = {
     variables: {
       slug: props.params.slug,
       skipCategoryTree: true,
-      imagePerSKUQuantity: props.imagePerSKUQuantity,
+      imageQuantity: props.imageQuantity,
       identifier: {
         field: 'id',
         value: props.params.id || '',

--- a/react/ProductContext.js
+++ b/react/ProductContext.js
@@ -126,6 +126,7 @@ const catalogOptions = {
     variables: {
       slug: props.params.slug,
       skipCategoryTree: true,
+      imagePerSKUQuantity: props.imagePerSKUQuantity,
       identifier: {
         field: 'id',
         value: props.params.id || '',


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### What problem is this solving?

Make it possible to control the maximum number of images the SKUs will have.

#### How should this be manually tested?

On this [workspace](https://iaronaraujo--storecomponents.myvtex.com/classic-shoes/p) this value is set to 1 so each SKU will only have one item.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/74442396-3282bb00-4e50-11ea-96ed-2824b5b995b1.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
