### PR TITLE
Navigation normalization option to disable lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add a navigation normalization option to disable lowercase
 
 ## [2.89.0] - 2020-02-28
 ### Added

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -69,15 +69,8 @@ const normalizeQueryMap = (pathSegments, mapSegments) => {
   }
 }
 
-const normalizeSearchNavigation = (pathSegments, map, segmentsToIgnore) => {
-  const mapSegments = map.split(',')
-  const normalizedSegments = pathSegments.map((segment, index) =>
-    segmentsToIgnore.includes(segment) ||
-    (mapSegments[index] && mapSegments[index].includes(SPEC_FILTER))
-      ? segment
-      : segment
-  )
-  return { pathSegments: normalizedSegments, map }
+const normalizeSearchNavigation = (pathSegments, map) => {
+  return { pathSegments, map }
 }
 
 const getIgnoredSegments = ignore => {
@@ -137,12 +130,10 @@ export const normalizeNavigation = navigation => {
     ? path.split(PATH_SEPARATOR).slice(1)
     : path.split(PATH_SEPARATOR)
 
-  const segmentsToIgnore = getIgnoredSegments(options)
-
   const normalizedNavigation =
     parsedQuery.query || isLegacySearchFormat(pathSegments, map)
       ? normalizeLegacySearchNavigation(pathSegments, parsedQuery, query)
-      : normalizeSearchNavigation(pathSegments, query, segmentsToIgnore)
+      : normalizeSearchNavigation(pathSegments, query)
 
   navigation.path = path.startsWith('/')
     ? '/' + normalizedNavigation.pathSegments.join('/')

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -70,8 +70,11 @@ const normalizeQueryMap = (pathSegments, mapSegments) => {
 }
 
 const normalizeSearchNavigation = (pathSegments, map, segmentsToIgnore) => {
-  const normalizedSegments = pathSegments.map(segment =>
-    segmentsToIgnore.includes(segment) ? segment : segment.toLowerCase()
+  const normalizedSegments = pathSegments.map((segment, index) =>
+    segmentsToIgnore.includes(segment) ||
+    (map[index] && map[index].includes(SPEC_FILTER))
+      ? segment
+      : segment.toLowerCase()
   )
   return { pathSegments: normalizedSegments, map }
 }

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -70,9 +70,10 @@ const normalizeQueryMap = (pathSegments, mapSegments) => {
 }
 
 const normalizeSearchNavigation = (pathSegments, map, segmentsToIgnore) => {
+  const mapSegments = map.split(',')
   const normalizedSegments = pathSegments.map((segment, index) =>
     segmentsToIgnore.includes(segment) ||
-    (map[index] && map[index].includes(SPEC_FILTER))
+    (mapSegments[index] && mapSegments[index].includes(SPEC_FILTER))
       ? segment
       : segment.toLowerCase()
   )

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -11,7 +11,7 @@ const isLegacySearchFormat = (pathSegments, map) => {
     return false
   }
   return (
-    map.includes(SPEC_FILTER) ||
+    map.includes(SPEC_FILTER) &&
     map.split(MAP_VALUES_SEP).length === pathSegments.length
   )
 }

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -75,7 +75,7 @@ const normalizeSearchNavigation = (pathSegments, map, segmentsToIgnore) => {
     segmentsToIgnore.includes(segment) ||
     (mapSegments[index] && mapSegments[index].includes(SPEC_FILTER))
       ? segment
-      : segment.toLowerCase()
+      : segment
   )
   return { pathSegments: normalizedSegments, map }
 }

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -1,4 +1,4 @@
-import { contains, path as ramdaPath, zip, flatten } from 'ramda'
+import { contains, path as ramdaPath, zip } from 'ramda'
 import queryString from 'query-string'
 
 const SPEC_FILTER = 'specificationFilter'
@@ -69,18 +69,14 @@ const normalizeQueryMap = (pathSegments, mapSegments) => {
   }
 }
 
-const normalizeSearchNavigation = (pathSegments, map) => {
-  return { pathSegments, map }
-}
-
-const getIgnoredSegments = ignore => {
-  return ignore
-    ? flatten(
-        Object.values(ignore).map(routeModifier =>
-          routeModifier.path.split(PATH_SEPARATOR)
-        )
-      )
-    : []
+const normalizeSearchNavigation = (pathSegments, map, options) => {
+  if (options && options.LOWERCASE === false) {
+    return { pathSegments, map }
+  }
+  return {
+    pathSegments: pathSegments.map(segment => segment.toLowerCase()),
+    map,
+  }
 }
 
 const normalizeLegacySearchNavigation = (pathSegments, queryMap, query) => {
@@ -133,7 +129,7 @@ export const normalizeNavigation = navigation => {
   const normalizedNavigation =
     parsedQuery.query || isLegacySearchFormat(pathSegments, map)
       ? normalizeLegacySearchNavigation(pathSegments, parsedQuery, query)
-      : normalizeSearchNavigation(pathSegments, query)
+      : normalizeSearchNavigation(pathSegments, query, options)
 
   navigation.path = path.startsWith('/')
     ? '/' + normalizedNavigation.pathSegments.join('/')


### PR DESCRIPTION
#### What is the purpose of this pull request?
Filter navigation tells store to not normalize it's filters, because the search is case sensitive.
Add a navigation normalization option to disable lowercase. 

Should be merged after: https://github.com/vtex-apps/search-result/pull/309

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
