### PR TITLE
Add new key `searchTerm` in the settingsSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Feature
-- Add new key `searchTerm` in the settingsSchema
+### Added
+- New settings `searchTermPath`
 
 ## [2.88.1] - 2020-02-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Feature
+- Add new key `searchTerm` in the settingsSchema
 
 ## [2.88.1] - 2020-02-27
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -94,10 +94,10 @@
         },
         "description": "Configure your store's favicons"
       },
-      "searchTerm": {
-        "title": "Search Term String",
+      "searchTermPath": {
+        "title": "Search Term Path",
         "type": "string",
-        "description": "Indicate the search term to use with the robots"
+        "description": "Indicate the search path of your store"
       }
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -93,6 +93,11 @@
           ]
         },
         "description": "Configure your store's favicons"
+      },
+      "searchTerm": {
+        "title": "Search Term String",
+        "type": "string",
+        "description": "Indicate the search term to use with the robots"
       }
     }
   },

--- a/react/HomeWrapper.js
+++ b/react/HomeWrapper.js
@@ -5,7 +5,8 @@ import SearchAction from 'vtex.structured-data/SearchAction'
 import useDataPixel from './hooks/useDataPixel'
 
 const HomeWrapper = ({ children }) => {
-  const { account, route } = useRuntime()
+  const { account, route, getSettings } = useRuntime()
+  const { searchTermPath } = getSettings('vtex.store')
 
   const pixelEvents = useMemo(() => {
     if (!canUseDOM) {
@@ -28,7 +29,7 @@ const HomeWrapper = ({ children }) => {
 
   return (
     <Fragment>
-      <SearchAction />
+      <SearchAction searchTermPath={searchTermPath} />
       {children}
     </Fragment>
   )


### PR DESCRIPTION
This new key is used in the component structured-data for set the search term for the robots of google

#### What is the purpose of this pull request?

Add new attribute for store settingsSchema

#### What problem is this solving?

Allow the configuration of the saerch term for google search

#### How should this be manually tested?

Yes

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/16216117/74875344-15f2f100-5330-11ea-9b3a-24fa153bf90f.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
