### PR TITLE
fix favicon for stores with relative favicon and root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Correctly display favicons for relative images in stores with rootpath.
 
 ## [2.88.0] - 2020-02-20
 ### Added

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -35,6 +35,22 @@ const systemToCanonical = ({ canonicalPath }) => {
   }
 }
 
+const useFavicons = faviconLinks => {
+  const { rootPath = '' } = useRuntime()
+  if (!rootPath) {
+    return faviconLinks
+  }
+
+  return (faviconLinks || []).map(favicon => {
+    // Only fix if is relative path
+    const { href } = favicon
+    if (!href || href[0] !== '/') {
+      return favicon
+    }
+    return { ...favicon, href: rootPath + href }
+  })
+}
+
 const StoreWrapper = ({ children }) => {
   const {
     amp,
@@ -90,6 +106,8 @@ const StoreWrapper = ({ children }) => {
     canonicalPath &&
     `https://${canonicalHost}${rootPath}${canonicalPath}`
 
+  const parsedFavicons = useFavicons(faviconLinks)
+
   return (
     <Fragment>
       <Helmet
@@ -118,7 +136,7 @@ const StoreWrapper = ({ children }) => {
           },
         ].filter(Boolean)}
         link={[
-          ...(faviconLinks || []),
+          ...(parsedFavicons || []),
           ...(!amp && canonicalLink
             ? [
                 /*{


### PR DESCRIPTION
#### What is the purpose of this pull request?

When configured with relative path, like `/arquivos/favicons.ico`, we have to append the rootpath of the store to properly display the favicon, result would be `us/arquivos/favicons.ico`

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
![image](https://user-images.githubusercontent.com/4925068/75449909-a04cdd80-594c-11ea-816f-7b3a59795710.png)

https://wwwuat.motorola.com/us/?workspace=fidbeta

https://www.als.com/?workspace=fidbeta still works

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
