### PR TITLE
Add `enableOrderFormOptimization` setting to the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `legacyOrderForm` setting.
+- `enableOrderFormOptimization` setting.
 
 ## [2.90.2] - 2020-03-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `legacyOrderForm` setting.
 
 ## [2.90.2] - 2020-03-09
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -97,10 +97,17 @@
         "type": "string",
         "description": "Indicate the search path of your store"
       },
-      "legacyOrderForm": {
-        "title": "Use legacy orderForm provider",
-        "type": "boolean",
-        "description": "Whether or not the legacy OrderFormProvider component should be rendered by your store. Setting this to true could lead to a less smooth browsing experience."
+      "advancedSettings": {
+        "title": "Advanced Store settings",
+        "type": "object",
+        "properties": {
+          "disableLegacyOrderForm": {
+            "title": "Disable legacy orderForm provider",
+            "type": "boolean",
+            "default": false,
+            "description": "Whether or not the legacy OrderFormProvider component should be used in your store. Read more about it at: https://vtex.io/docs/"
+          }
+        }
       }
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -101,11 +101,11 @@
         "title": "Advanced Store settings",
         "type": "object",
         "properties": {
-          "disableLegacyOrderForm": {
-            "title": "Disable legacy orderForm provider",
+          "enableOrderFormOptimization": {
+            "title": "Enable orderForm optimization",
             "type": "boolean",
             "default": false,
-            "description": "Whether or not the legacy OrderFormProvider component should be used in your store. Read more about it at: https://vtex.io/docs/"
+            "description": "This setting disables the legacy orderForm provider. More at: https://vtex.io/docs"
           }
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -105,7 +105,7 @@
             "title": "Enable orderForm optimization",
             "type": "boolean",
             "default": false,
-            "description": "This setting disables the legacy orderForm provider. More at: https://vtex.io/docs"
+            "description": "This setting disables the legacy orderForm provider. More at: https://vtex.io/docs/recipes/store-management/enabling-order-form-optimization."
           }
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -88,10 +88,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "Configure your store's favicons"
       },
@@ -103,7 +100,7 @@
       "legacyOrderForm": {
         "title": "Use legacy orderForm provider",
         "type": "boolean",
-        "description": "Whether or not the legacy OrderFormProvider component should be rendered by your store. Setting this to true could hurt performance"
+        "description": "Whether or not the legacy OrderFormProvider component should be rendered by your store. Setting this to true could lead to a less smooth browsing experience."
       }
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -99,6 +99,11 @@
         "title": "Search Term Path",
         "type": "string",
         "description": "Indicate the search path of your store"
+      },
+      "legacyOrderForm": {
+        "title": "Use legacy orderForm provider",
+        "type": "boolean",
+        "description": "Whether or not the legacy OrderFormProvider component should be rendered by your store. Setting this to true could hurt performance"
       }
     }
   },

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -93,7 +93,7 @@ const StoreWrapper = ({ children }) => {
     metaTagRobots,
     storeName,
     faviconLinks,
-    disableLegacyOrderForm = false,
+    enableOrderFormOptimization = false,
   } = settings
 
   const { canonicalHost, canonicalPath } = systemToCanonical(route)
@@ -169,7 +169,7 @@ const StoreWrapper = ({ children }) => {
           <UserDataPixel />
           <ToastProvider positioning="window">
             <NetworkStatusToast />
-            {disableLegacyOrderForm ? (
+            {enableOrderFormOptimization ? (
               childrenWithNewOrderForm
             ) : (
               <OrderFormProvider>{childrenWithNewOrderForm}</OrderFormProvider>

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -109,7 +109,7 @@ const StoreWrapper = ({ children }) => {
 
   const parsedFavicons = useFavicons(faviconLinks)
 
-  const childrenWithNewOrderForm = (
+  const content = (
     <OrderQueueProvider>
       <OrderFormProviderCheckout>
         <OrderItemsProvider>
@@ -170,9 +170,9 @@ const StoreWrapper = ({ children }) => {
           <ToastProvider positioning="window">
             <NetworkStatusToast />
             {enableOrderFormOptimization ? (
-              childrenWithNewOrderForm
+              content
             ) : (
-              <OrderFormProvider>{childrenWithNewOrderForm}</OrderFormProvider>
+              <OrderFormProvider>{content}</OrderFormProvider>
             )}
           </ToastProvider>
         </PWAProvider>

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -93,7 +93,7 @@ const StoreWrapper = ({ children }) => {
     metaTagRobots,
     storeName,
     faviconLinks,
-    legacyOrderForm = true,
+    disableLegacyOrderForm = false,
   } = settings
 
   const { canonicalHost, canonicalPath } = systemToCanonical(route)
@@ -169,10 +169,10 @@ const StoreWrapper = ({ children }) => {
           <UserDataPixel />
           <ToastProvider positioning="window">
             <NetworkStatusToast />
-            {legacyOrderForm ? (
-              <OrderFormProvider>{childrenWithNewOrderForm}</OrderFormProvider>
-            ) : (
+            {disableLegacyOrderForm ? (
               childrenWithNewOrderForm
+            ) : (
+              <OrderFormProvider>{childrenWithNewOrderForm}</OrderFormProvider>
             )}
           </ToastProvider>
         </PWAProvider>

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -172,6 +172,11 @@ const StoreWrapper = ({ children }) => {
             {enableOrderFormOptimization ? (
               content
             ) : (
+              /** This is necessary for backwards compatibility, since stores
+               *  might still need the OrderFormProvider from store-resources.
+               *  If a store does not have `enableOrderFormOptimization` enabled,
+               *  we should always add this provider.
+               */
               <OrderFormProvider>{content}</OrderFormProvider>
             )}
           </ToastProvider>

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -93,6 +93,7 @@ const StoreWrapper = ({ children }) => {
     metaTagRobots,
     storeName,
     faviconLinks,
+    legacyOrderForm = true,
   } = settings
 
   const { canonicalHost, canonicalPath } = systemToCanonical(route)
@@ -108,6 +109,17 @@ const StoreWrapper = ({ children }) => {
 
   const parsedFavicons = useFavicons(faviconLinks)
 
+  const childrenWithNewOrderForm = (
+    <OrderQueueProvider>
+      <OrderFormProviderCheckout>
+        <OrderItemsProvider>
+          <WrapperContainer className="vtex-store__template bg-base">
+            {children}
+          </WrapperContainer>
+        </OrderItemsProvider>
+      </OrderFormProviderCheckout>
+    </OrderQueueProvider>
+  )
   return (
     <Fragment>
       <Helmet
@@ -157,17 +169,11 @@ const StoreWrapper = ({ children }) => {
           <UserDataPixel />
           <ToastProvider positioning="window">
             <NetworkStatusToast />
-            <OrderFormProvider>
-              <OrderQueueProvider>
-                <OrderFormProviderCheckout>
-                  <OrderItemsProvider>
-                    <WrapperContainer className="vtex-store__template bg-base">
-                      {children}
-                    </WrapperContainer>
-                  </OrderItemsProvider>
-                </OrderFormProviderCheckout>
-              </OrderQueueProvider>
-            </OrderFormProvider>
+            {legacyOrderForm ? (
+              <OrderFormProvider>{childrenWithNewOrderForm}</OrderFormProvider>
+            ) : (
+              childrenWithNewOrderForm
+            )}
           </ToastProvider>
         </PWAProvider>
       </PixelProvider>

--- a/react/package.json
+++ b/react/package.json
@@ -25,7 +25,7 @@
     "react-apollo": "^2.0.4",
     "react-dom": "^16.2.0",
     "react-intl": "3.9.1",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   },
   "version": "2.90.2"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5313,10 +5313,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.3.3333:
   version "3.6.3"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adding a new `enableOrderFormOptimization` setting to the app, which enables users to control whether or not the "legacy" `OrderFormProvider` (the one that does not use `checkout-graphql`) is rendered by the `StoreWrapper` component.

#### What problem is this solving?

This should enable stores to be faster by not having two different orderForms being loaded.

#### How should this be manually tested?

1. Go to [Workspace with enableOrderFormOptimization = `true`](https://victorhmp--storecomponents.myvtex.com/), where this setting is set to `true`.
2. Open Apollo DevTools and check the queries being performed to render the page. You should see only one mention of `orderForm`, which is a query performed by the *new* OrderFormProvider to `checkout-graphql`.
3. Go to [Workspace with enableOrderFormOptimization = `false`](https://victormiranda--storecomponents.myvtex.com/), where this setting was not set (using the default `false` value).
4. Repeat step 2., but this time you should be able to spot **two** `orderForm` queries being performed. Each one of them used by a different OrderFormProvider.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

#### Notes

This is related to: https://github.com/vtex-apps/admin-pages/pull/329 and https://github.com/vtex-apps/io-documentation/pull/524
