### PR TITLE
Feature/experimental lazy assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `__fold__.experimentalLazyAssets`.
 
 ## [2.90.2] - 2020-03-09
 ### Changed

--- a/react/package.json
+++ b/react/package.json
@@ -25,7 +25,7 @@
     "react-apollo": "^2.0.4",
     "react-dom": "^16.2.0",
     "react-intl": "3.9.1",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   },
   "version": "2.90.2"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5313,10 +5313,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.3.3333:
   version "3.6.3"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -121,5 +121,6 @@
   },
   "__fold__.mobile": {},
   "__fold__.desktop": {},
-  "__fold__.experimentalLazyImages": {}
+  "__fold__.experimentalLazyImages": {},
+  "__fold__.experimentalLazyAssets": {}
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds support for `__fold__.experimentalLazyAssets`.

Required PRs:
https://github.com/vtex-apps/render-runtime/pull/497
https://github.com/vtex/render-server/pull/566
https://github.com/vtex/pages-graphql/pull/348
https://github.com/vtex-apps/store/pull/437
https://github.com/vtex/builder-hub/pull/952

Related PRs:
https://github.com/vtex-apps/store-theme/pull/210
https://github.com/vtex-apps/store-footer/pull/105

### How to test:
https://partialhydration--storecomponents.myvtex.com/
Currently only applied on the home.

Open the page with the network Dev Tools tab filtered by JS.
After the page loads, scroll down slowly, and notice that the assets related to the components that appear into view are being loaded.

Navigate around other pages to check that nothing breaks.

Next, open https://partialhydration--storecomponents.myvtex.com?__disableSSR and verify that it works properly

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
