### PR TITLE
add new props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `__unstableProductOrigin`, `fuzzy`, `operator` and `searchState` props.
+
 ## [2.93.3] - 2020-04-02
 ### Fixed
 - Do not apply lowercase on navigate for new search URL format

--- a/react/SearchContext.js
+++ b/react/SearchContext.js
@@ -30,8 +30,12 @@ const SearchContext = ({
     priceRange,
     // backwards-compatibility
     rest,
+    fuzzy,
+    operator,
+    searchState,
   },
   children,
+  __unstableProductOriginVtex,
 }) => {
   const { page: runtimePage, query: runtimeQuery } = useRuntime()
 
@@ -87,6 +91,10 @@ const SearchContext = ({
       skusFilter={skusFilter}
       simulationBehavior={simulationBehavior}
       installmentCriteria={installmentCriteria}
+      operator={operator}
+      fuzzy={fuzzy}
+      searchState={searchState}
+      __unstableProductOriginVtex={__unstableProductOriginVtex}
     >
       {(searchQuery, extraParams) => {
         return React.cloneElement(children, {
@@ -139,6 +147,9 @@ SearchContext.propTypes = {
     order: PropTypes.oneOf(SORT_OPTIONS.map(o => o.value)),
     priceRange: PropTypes.string,
     rest: PropTypes.any,
+    operator: PropTypes.string,
+    fuzzy: PropTypes.string,
+    searchState: PropTypes.string,
   }),
   /** Custom query `query` param */
   queryField: PropTypes.string,
@@ -157,6 +168,7 @@ SearchContext.propTypes = {
   skusFilter: PropTypes.string,
   simulationBehavior: PropTypes.string,
   installmentCriteria: PropTypes.string,
+  __unstableProductOriginVtex: PropTypes.bool,
 }
 
 SearchContext.schema = {


### PR DESCRIPTION
#### What problem is this solving?

Currently, VTEX has its own protocol between the search API and the UX components. This protocol forces new search-engines to implement specific rules to communicate with the UX. The [`search-protocol`](https://github.com/vtex/search-protocol) project purposes a generic way to make the UX/API communication.

This PR adds 4 props that are essential for new search engines.
Three of them behave like `page` and it appears in the URL as queryStrings. They are `fuzzy`, `operator` and `searchState`.
The other one, `__unstableProductOriginVtex`, doesn't have a relation with the URL.
You can check the definition of each one in the [`search-protocol`](https://github.com/vtex/search-protocol) project.

#### How should this be manually tested?
Navigate to a fulltext search, click on the facets or the fetch more button to see the URL changing.
[Workspace](https://hiagolucas--storecomponents.myvtex.com/shirt?_q=shirt&map=ft)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
