### PR TITLE
Pass setCheckoutCookie prop to OrderFormProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `setCheckoutCookie` argument to control whether or not `vtex.checkout-graphql` not set the `'checkout.vtex.com'` cookie.
 
 ## [2.93.0] - 2020-03-24
 ### Added


### PR DESCRIPTION
#### What is the purpose of this pull request?

Pass a new `setCheckoutCookie` prop to `OrderFormProvider` from `vtex.order-manager` to prevent `vtex.checkout-graphql`' `orderForm` query  from overwriting the `checkout.vtex.com` cookie set by `vtex.store-graphql` when a store uses **both** the legacy and the new `OrderFormProvider`s.

#### What problem is this solving?

Prevents unpredictable behavior when a store is using **two** `OrderFormProvider`s.

#### How should this be manually tested?

1. Go to [this workspace](https://victorhmp--storecomponents.myvtex.com/), where there is only the new `OrderFormProvider` being used (`orderFormOptimization` is enabled), and see that the store is functioning as it should;
2. Go to [this workspace](https://victorhmp--alssports.myvtex.com/) where there are **two** `OrderFormProvider`s being used, along with the legacy `minicart` and `buy-button` blocks, instead of the new ones, which means they consume and alter the legacy `OrderFormContext`;
3. Check that adding, removing and changing the number of items in the `minicart` all work as expected.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

#### Notes

Depends on

- https://github.com/vtex/checkout-graphql/pull/58
- https://github.com/vtex-apps/checkout-resources/pull/43
- https://github.com/vtex-apps/order-manager/pull/38