### PR TITLE
Remove *terms of subcategory canonical template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove `*terms` of subcategory canonical template
 
 ## [2.93.1] - 2020-03-26
 ### Added

--- a/store/routes.json
+++ b/store/routes.json
@@ -42,7 +42,7 @@
   },
   "store.search#subcategory": {
     "path": "/_v/segment/routing/vtex.store@2.x/subcategory/:id/:department/:category/:subcategory(/*terms)",
-    "canonical": "/:department/:category/:subcategory(/*terms)",
+    "canonical": "/:department/:category/:subcategory",
     "map": ["c", "c", "c"],
     "contentType": "subcategory",
     "fallbackEntity": "category"


### PR DESCRIPTION
#### What is the purpose of this pull request?
This issue is a regression we had. It is happening because we’ve made a change to support category trees with length greater than 3, the max was 3 before. The canonical calculation was simpler though, any path with size greater than 3 was discarded. 

This PR places this behaviour back and will remove canonicals with path greater than 3. There should be additional effort later to improve canonical calculation logic.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
![image (7)](https://user-images.githubusercontent.com/1594322/78159858-873abf00-7419-11ea-91ee-b040b6720da3.png)


#### How should this be manually tested?
Look for the canonical at, it should be: https://jey--eriksbikeshop.myvtex.com/cycling/bicycles/road

https://jey--eriksbikeshop.myvtex.com/cycling/bicycles/road/Dropbar?map=c,c,c,specificationFilter_254

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
