### PR TITLE
Remove navigation normalization for new search URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Do not apply lowercase on navigate for new search URL format
 
 ## [2.93.2] - 2020-04-01
 ### Fixed

--- a/react/__tests__/navigation.test.js
+++ b/react/__tests__/navigation.test.js
@@ -29,7 +29,7 @@ describe('Navigation route modifier', () => {
     expect(result).toEqual({ path: expectedPath, query: expectedQuery })
   })
   it('should preserve case for new routes pattern', () => {
-    const path = '/foo/Bar/nice_Bar'
+    const path = '/foo/bar/nice_Bar'
     const expectedPath = '/foo/bar/nice_Bar'
     const ignore = { 'nice-bar': { path: 'nice_Bar' } }
     const result = normalizeNavigation({ path, ignore })

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -10,10 +10,7 @@ const isLegacySearchFormat = (pathSegments, map) => {
   if (!map) {
     return false
   }
-  return (
-    map.includes(SPEC_FILTER) &&
-    map.split(MAP_VALUES_SEP).length === pathSegments.length
-  )
+  return map.split(MAP_VALUES_SEP).length === pathSegments.length
 }
 
 const categoriesInSequence = mapValues => {
@@ -69,12 +66,9 @@ const normalizeQueryMap = (pathSegments, mapSegments) => {
   }
 }
 
-const normalizeSearchNavigation = (pathSegments, map, options) => {
-  if (options && options.LOWERCASE === false) {
-    return { pathSegments, map }
-  }
+const normalizeSearchNavigation = (pathSegments, map) => {
   return {
-    pathSegments: pathSegments.map(segment => segment.toLowerCase()),
+    pathSegments: pathSegments,
     map,
   }
 }
@@ -118,7 +112,7 @@ export const normalizeNavigation = navigation => {
     return navigation
   }
 
-  const { path, query, options } = navigation
+  const { path, query } = navigation
   const parsedQuery = query ? queryString.parse(query) : {}
   const { map } = parsedQuery
 
@@ -129,7 +123,7 @@ export const normalizeNavigation = navigation => {
   const normalizedNavigation =
     parsedQuery.query || isLegacySearchFormat(pathSegments, map)
       ? normalizeLegacySearchNavigation(pathSegments, parsedQuery, query)
-      : normalizeSearchNavigation(pathSegments, query, options)
+      : normalizeSearchNavigation(pathSegments, query)
 
   navigation.path = path.startsWith('/')
     ? '/' + normalizedNavigation.pathSegments.join('/')


### PR DESCRIPTION
#### What is the purpose of this pull request?
We apply a normalization, i.e lowercasing path segments when navigating. Search URLs filters can't be lower cased because the search result index is case sensitive. The normalization ignores paths relatives to specificationFilters. However, as we've changed URL structure for specification filters, removing from querystring and only passing them through the path, with the format `filterName_filterValue`, we can't read this information anymore.

This PR removes the lowercasing when the URL follows the new format structure. i.e `filterName_filterValue`

#### What problem is this solving?
1 - When navigating trough the menu in worldwidegolf any link under apparel/Men's categories.
You will notice that the filter is getting lowercased and the results are empty.

https://worldwidegolf.myvtex.com

#### How should this be manually tested?
Repeat the same steps above for this workspace, you'll see that this time we have search results.
https://jey--worldwidegolf.myvtex.com

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
