### PR TITLE
Add `store.custom` route template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add store.custom route template
 
 ## [2.94.1] - 2020-04-08
 ### Fixed

--- a/store/routes.json
+++ b/store/routes.json
@@ -56,6 +56,11 @@
   "store.offline": {
     "path": "/_v/offline"
   },
+  "store.custom": {
+    "path": "/_v/segment/routing/vtex.store@2.x/userRoute/:id(/*terms)",
+    "contentType": "userRoute",
+    "canonical": "/*terms"
+  },
   "store.not-found#product": {
     "path": "/_v/segment/routing/vtex.store@2.x/notFoundProduct/:id/:slug/p",
     "canonical": "/:slug/p",


### PR DESCRIPTION
#### What is the purpose of this pull request?
User routes will be supported by render as rewriter internal routes.
They will have the following pattern /_v/segment/routing/vtex.store@2.x/userRoute/:id/*tems where id and terms are routeId and pathId respectively.
This PR enables rewriter to understand this route format for store.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Open:
https://jey--storecomponents.myvtex.com/_v/segment/routing/vtex.store@2.x/userRoute/vtex.store@2.x:store.custom::renato/renato

It should open a custom landing page for the route `/renato`
<img width="1677" alt="Screen Shot 2020-04-08 at 17 20 03" src="https://user-images.githubusercontent.com/1594322/78829704-3567db00-79bd-11ea-9295-52efb0bbf6de.png">


#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
