### PR TITLE
Copy settingsSchema do contentSchemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Copy the `settingsSchema` to a `contentSchemas.json` so it can have translated attributes.
+- Make the `metaTagDescription` and `titleTag` translatable.
 
 ## [2.95.1] - 2020-04-09
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,7 @@
     "vtex.product-specification-badges": "0.x",
     "vtex.product-review-interfaces": "1.x",
     "vtex.rich-text": "0.x",
+    "vtex.native-types": "0.x",
     "vtex.telemarketing": "2.x"
   },
   "settingsSchema": {

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,0 +1,82 @@
+{
+  "definitions": {
+    "StoreSettings": {
+      "title": "VTEX Store",
+      "type": "object",
+      "properties": {
+        "storeName": {
+          "title": "Store Name",
+          "type": "string"
+        },
+        "requiresAuthorization": {
+          "title": "Enables B2B behavior",
+          "type": "boolean"
+        },
+        "titleTag": {
+          "title": "Default title tag",
+          "$ref": "app:vtex.native-types#/definitions/text"
+        },
+        "metaTagDescription": {
+          "title": "Meta description tag",
+          "$ref": "app:vtex.native-types#/definitions/text"
+        },
+        "metaTagRobots": {
+          "title": "Meta robots tag",
+          "type": "string",
+          "description": "Default value: index, follow"
+        },
+        "faviconLinks": {
+          "title": "Favicons",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rel": {
+                "title": "Favicon Relationship",
+                "type": "string",
+                "description": "This favicon relationship, e.g: 'icon', 'shortcut icon', 'apple-touch-icon'"
+              },
+              "type": {
+                "title": "Favicon Media Type",
+                "type": "string",
+                "description": "(Optional) Favicon type, e.g: image/png"
+              },
+              "sizes": {
+                "title": "Favicon Size",
+                "type": "string",
+                "pattern": "^[0-9]+x[0-9]+$",
+                "description": "(Optional) Favicon size, format: {width}x{height} e.g: 180x180"
+              },
+              "href": {
+                "title": "Favicon href",
+                "type": "string"
+              }
+            },
+            "required": [
+              "rel",
+              "href"
+            ]
+          },
+          "description": "Configure your store's favicons"
+        },
+        "searchTermPath": {
+          "title": "Search Term Path",
+          "type": "string",
+          "description": "Indicate the search path of your store"
+        },
+        "advancedSettings": {
+          "title": "Advanced Store settings",
+          "type": "object",
+          "properties": {
+            "enableOrderFormOptimization": {
+              "title": "Enable orderForm optimization",
+              "type": "boolean",
+              "default": false,
+              "description": "This setting disables the legacy orderForm provider. More at: https://vtex.io/docs/recipes/store-management/enabling-order-form-optimization."
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

It's not possible to translate the title tag and the description of the store. To do that we need to make the type of `titleTag` and `metaTagDescription`  as `app:vtex.native-types#/definitions/text`, but `settingsSchema` doesn't support this, so we are moving this settings to a `contentSchemas`.

#### What problem is this solving?

https://github.com/vtex-apps/store-discussion/issues/269

#### How should this be manually tested?

(This workspace should be working after all the other apps responsible to the changes have it deployed](https://github.com/vtex-apps/store/pull/449)

#### Extra information

* In order for this to work the CMS team has to make some changes.
* The definition in `settingsSchema` will only be removed after everything is working using the `contentSchemas` definition

#### Types of changes

* [] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

