### PR TITLE
Read `idsku` and `skuId` query string to render product Microdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Read `idsku` and `skuId` query string to render product Microdata.
 
 ## [1.39.1] - 2019-06-26
 

--- a/react/ProductContextProvider.js
+++ b/react/ProductContextProvider.js
@@ -162,9 +162,12 @@ class ProductContextProvider extends Component {
     }
   }
 
+  getSelectedSKUFromQueryString = (query) => query && query.skuId || query.idsku
+
   render() {
     const {
       params: { slug },
+      query,
       client,
     } = this.props
 
@@ -201,6 +204,8 @@ class ProductContextProvider extends Component {
       categories: product ? product.categories : null,
     }
 
+    const selectedItem = this.getSelectedSKUFromQueryString(query)
+
     return (
       <div className="vtex-product-context-provider">
         <Helmet>
@@ -211,7 +216,7 @@ class ProductContextProvider extends Component {
         </Helmet>
         {
           <Fragment>
-            {product && <MicroData product={product} />}
+            {product && <MicroData product={product} selectedItem={selectedItem} />}
             <DataLayerApolloWrapper getData={this.getData} loading={loading}>
               {React.cloneElement(this.props.children, {
                 productQuery,

--- a/react/package.json
+++ b/react/package.json
@@ -41,7 +41,7 @@
     "tslint": "^5.11.0",
     "tslint-config-vtex": "^2.0.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "^3.1.1"
+    "typescript": "3.8.3"
   },
   "jest": {
     "verbose": true,

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4889,10 +4889,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.1.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
-  integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
## That's a fix for store@1.x

#### What is the purpose of this pull request?

Read `idsku` and `skuId` query string to render product Microdata

#### What problem is this solving?

Rendering MicroData from another SKU that is unavailable.

#### How should this be manually tested?

Open:
https://brenovtex--brastemp.myvtex.com/maquina-de-bebidas-brastemp-b-blend-com-purificador-roxo-bpg40c2/p?idsku=3260201241

Open Elements tab o Chrome Dev Tools e look for "schema"

![image](https://user-images.githubusercontent.com/284515/81616493-eb0dbb80-93b9-11ea-8519-361c52aee3d4.png)

The current schema in production:

![image](https://user-images.githubusercontent.com/284515/81616537-0678c680-93ba-11ea-8cac-e81467987841.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
