### PR TITLE
New full text search URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `store.search` and `store.search#configurable` paths so we can have 404 pages.
 
 ## [2.95.5] - 2020-05-04
 ### Fixed

--- a/react/SearchContext.js
+++ b/react/SearchContext.js
@@ -28,6 +28,7 @@ const SearchContext = ({
     page: pageQuery,
     map: mapQuery,
     priceRange,
+    _q,
     // backwards-compatibility
     rest,
     fuzzy,
@@ -60,6 +61,10 @@ const SearchContext = ({
 
   // Remove params which don't compose a search path
   const { id, ...searchParams } = params
+  // TODO: validate if this check is enough, if there is any other case in which terms can be nothing
+  if (params.terms === "") {
+    searchParams._q = _q
+  }
   const query = Object.values(searchParams)
     .filter(term => term && term.length > 0)
     .join('/')

--- a/store/routes.json
+++ b/store/routes.json
@@ -15,7 +15,6 @@
   },
   "store.search": {
     "path": "/s/*terms",
-    "canonical": "/s/*terms",
     "contentType": "search"
   },
   "store.search#brand": {

--- a/store/routes.json
+++ b/store/routes.json
@@ -15,6 +15,7 @@
   },
   "store.search": {
     "path": "/s/*terms",
+    "canonical": "/s/*terms",
     "contentType": "search"
   },
   "store.search#brand": {
@@ -42,7 +43,7 @@
     "contentType": "subcategory"
   },
   "store.search#configurable": {
-    "path": "/s/*terms"
+    "path": "/search/*terms"
   },
   "store.orderplaced": {
     "path": "/checkout/orderPlaced"

--- a/store/routes.json
+++ b/store/routes.json
@@ -14,8 +14,7 @@
     "contentType": "product"
   },
   "store.search": {
-    "path": "/:term/s",
-    "canonical": "/:term",
+    "path": "/s/*terms",
     "contentType": "search"
   },
   "store.search#brand": {

--- a/store/routes.json
+++ b/store/routes.json
@@ -42,7 +42,7 @@
     "contentType": "subcategory"
   },
   "store.search#configurable": {
-    "path": "/search/*terms"
+    "path": "/searchc/*terms"
   },
   "store.orderplaced": {
     "path": "/checkout/orderPlaced"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change the `store.search`'s path so we can have 404 pages. The problem of this PR is that it breaks some stores that have custom components (eg. Boticario and Motorolaus)

Needs https://github.com/vtex-apps/store-components/pull/772 to work properly with our SearchBar.


#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
