### PR TITLE
Add operator, searchState and correction to SearchMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `operator`, `searchState` and `correction` to SearchMetadata
 
 ## [2.95.6] - 2020-06-01
 ### Fixed

--- a/react/modules/searchMetadata.test.ts
+++ b/react/modules/searchMetadata.test.ts
@@ -128,6 +128,9 @@ test('should get the searched metadata', () => {
           href: '/electronics/top?map=c,ft',
         },
       ],
+      operator: 'and',
+      searchState: 'placeholder',
+      correction: { misspelled: false },
     },
     facets: {
       categoriesTrees: [
@@ -147,6 +150,9 @@ test('should get the searched metadata', () => {
   expect(result!.category!.id).toBe('1')
   expect(result!.category!.name).toBe('foo')
   expect(result!.results).toBe(3)
+  expect(result!.operator).toBe('and')
+  expect(result!.searchState).toBe('placeholder')
+  expect(result!.correction!.misspelled).toBe(false)
 })
 
 test('should get the searched metadata without category', () => {
@@ -159,6 +165,9 @@ test('should get the searched metadata without category', () => {
           href: '/electronics/top?map=c,ft',
         },
       ],
+      operator: 'and',
+      searchState: 'placeholder',
+      correction: { misspelled: true },
     },
     facets: {
       categoriesTrees: [
@@ -177,4 +186,7 @@ test('should get the searched metadata without category', () => {
   expect(result!.term).toBe('Top')
   expect(result!.category).toBeNull()
   expect(result!.results).toBe(3)
+  expect(result!.operator).toBe('and')
+  expect(result!.searchState).toBe('placeholder')
+  expect(result!.correction!.misspelled).toBe(true)
 })

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -95,5 +95,8 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
     term: searchTerm.name,
     category: department ? { id: department.id, name: department.name } : null,
     results: searchQuery.productSearch.recordsFiltered,
+    operator: searchQuery.productSearch.operator,
+    searchState: searchQuery.productSearch.searchState,
+    correction: searchQuery.productSearch.correction,
   }
 }

--- a/react/modules/searchTypes.ts
+++ b/react/modules/searchTypes.ts
@@ -16,6 +16,11 @@ export interface SearchQueryData {
   productSearch?: {
     breadcrumb: Breadcrumb[]
     recordsFiltered: number
+    operator?: string
+    searchState?: string
+    correction?: {
+      misspelled: boolean
+    }
   }
   facets?: {
     categoriesTrees?: CategoriesTrees[]


### PR DESCRIPTION
#### What is the purpose of this pull request?

Extend the information provided by the `pageInfo` event when inside search pages, which will include a bit more information about the query that can be used by VTEX Intelligent Search and other 3rd party search providers to help gather analytics info about the queries being executed.

#### What problem is this solving?

Gather analytics information, in VTEX Intelligent Search's case, this is stored and used to provide usage reports, conversion metrics, and boost popular products.

#### How should this be manually tested?

Check the value stored in `window.pixelManagerEvents` on both workspaces below:

- `vtex.search-resolver@0.x`: https://christian--storecomponents.myvtex.com/shirt?_q=shirt&map=ft
- `vtex.search-resolver@1.x`: https://christiansearch--storecomponents.myvtex.com/shirt?_q=shirt&map=ft

#### Screenshots or example usage

- Using `vtex.search-resolver@0.x`:
![image](https://user-images.githubusercontent.com/34144667/82823291-ad129c00-9e7d-11ea-90d1-692c88545b36.png)

- Using `vtex.search-resolver@1.x`:
![image](https://user-images.githubusercontent.com/34144667/82823336-c3205c80-9e7d-11ea-8d97-abb25ae7629e.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
