### PR TITLE
Replace navigate with location.assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Redirect after login at the ProfileChallenge.
 
 ## [2.95.5] - 2020-05-04
 ### Fixed

--- a/react/ProfileChallenge.tsx
+++ b/react/ProfileChallenge.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, FC } from 'react'
 import {
-  useRuntime,
   canUseDOM,
   Loading,
   SessionResponse,
@@ -50,8 +49,6 @@ function hasSession(session: SessionResponse | undefined): session is Session {
 }
 
 const useLoginRedirect = (isLoggedIn: boolean | null, page: string) => {
-  const { navigate } = useRuntime()
-
   useEffect(() => {
     const { url, pathName } = getLocation()
 
@@ -60,12 +57,9 @@ const useLoginRedirect = (isLoggedIn: boolean | null, page: string) => {
       page !== 'store.login' &&
       pathName !== loginPath
     ) {
-      navigate({
-        fallbackToWindowLocation: false,
-        to: `${loginPath}?returnUrl=${encodeURIComponent(url)}`,
-      })
+      window.location.assign(`${loginPath}?returnUrl=${encodeURIComponent(url)}`)
     }
-  }, [page, navigate, isLoggedIn])
+  }, [page, isLoggedIn])
 }
 
 interface Props {

--- a/react/ProfileChallenge.tsx
+++ b/react/ProfileChallenge.tsx
@@ -51,13 +51,15 @@ function hasSession(session: SessionResponse | undefined): session is Session {
 const useLoginRedirect = (isLoggedIn: boolean | null, page: string) => {
   useEffect(() => {
     const { url, pathName } = getLocation()
-
     if (
       isLoggedIn === false &&
       page !== 'store.login' &&
-      pathName !== loginPath
+      pathName !== loginPath &&
+      canUseDOM
     ) {
-      window.location.assign(`${loginPath}?returnUrl=${encodeURIComponent(url)}`)
+      window.location.assign(
+        `${loginPath}?returnUrl=${encodeURIComponent(url)}`
+      )
     }
   }, [page, isLoggedIn])
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix redirect after login. 

#### What problem is this solving?
`navigate` from render-runtime [parses the query string](https://github.com/vtex-apps/render-runtime/blob/master/react/utils/pages.ts#L108) and is [no longer re-encoding it](https://github.com/vtex-apps/render-runtime/pull/380). Since the `returnUrl` query string needs to be encoded for the redirect to work, the `navigate` method had to be replaced.

#### How should this be manually tested?
1. Without login into your store account, try reaching this page: https://challenge--recorrenciaqa.myvtex.com/account#/orders
- it should redirect you to log in.
2. After logging in, you should be redirected to the URL above.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
