### PR TITLE
Add imageUrl and detailUrl to productView event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Property `detailUrl` to `productView` event
+- Property `items.imageUrl` and `selectedSku.imageUrl` to `productView` event
 
 ## [2.95.7] - 2020-06-02
 ### Added

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -110,7 +110,8 @@ function getSkuProperties(item: SKU): SKUEvent {
     name: item.name,
     ean: item.ean,
     referenceId: item.referenceId,
-    imageUrl: item.images && item.images.length > 0 ? item.images[0].imageUrl : '',
+    imageUrl:
+      item.images && item.images.length > 0 ? item.images[0].imageUrl : '',
     sellers: item.sellers.map(seller => ({
       sellerId: seller.sellerId,
       commertialOffer: {

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -27,6 +27,7 @@ interface Product {
 }
 
 interface ProductViewEvent {
+  detailUrl: string
   brand: string
   brandId: string
   productReference: string
@@ -36,8 +37,8 @@ interface ProductViewEvent {
   categoryTree: Category[]
   productId: string
   productName: string
-  items: SKU[]
-  selectedSku: SKU
+  items: SKUEvent[]
+  selectedSku: SKUEvent
 }
 
 interface Category {
@@ -45,12 +46,23 @@ interface Category {
   name: string
 }
 
+interface SKUEvent extends Omit<SKU, 'images'> {
+  imageUrl: string
+}
+
 interface SKU {
   itemId: string
   ean: string
   name: string
+  images: Image[]
   referenceId: [{ Value: string }]
   sellers: Seller[]
+}
+
+interface Image {
+  imageId: string
+  imageLabel: string
+  imageUrl: string
 }
 
 interface Seller {
@@ -92,12 +104,13 @@ function usePageInfo(
   useDataPixel(pageEvents, path(['linkText'], product), loading)
 }
 
-function getSkuProperties(item: SKU) {
+function getSkuProperties(item: SKU): SKUEvent {
   return {
     itemId: item.itemId,
     name: item.name,
     ean: item.ean,
     referenceId: item.referenceId,
+    imageUrl: item.images && item.images.length > 0 ? item.images[0].imageUrl : '',
     sellers: item.sellers.map(seller => ({
       sellerId: seller.sellerId,
       commertialOffer: {
@@ -122,6 +135,7 @@ function useProductEvents(
     }
 
     const eventProduct: ProductViewEvent = {
+      detailUrl: `/${product.linkText}/p`,
       brand: product.brand,
       brandId: product.brandId,
       productReference: product.productReference,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add more data to productView event to be able to implement Klaviyo pixel app.

#### How should this be manually tested?

1. Open: https://breno2--storecomponents.myvtex.com/wood-clock/p
2. Check `pixelManagerEvents` variable in dev tools
3. Open the `productView` event

![image](https://user-images.githubusercontent.com/284515/83445979-529cb100-a424-11ea-94c8-3e6fefd360a6.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
