### PR TITLE
 decode forward slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Decode forward slash in search term.
 
 ## [2.101.0] - 2020-08-12
 ### Added

--- a/react/SearchContext.js
+++ b/react/SearchContext.js
@@ -6,7 +6,6 @@ import { useRuntime } from 'vtex.render-runtime'
 import SearchQuery from 'vtex.search-result/SearchQuery'
 
 import { initializeMap, SORT_OPTIONS } from './modules/search'
-import decodeForwardSlash from './utils/decodeForwardSlash'
 
 const DEFAULT_MAX_ITEMS_PER_PAGE = 10
 
@@ -82,7 +81,7 @@ const SearchContext = ({
     return query
   }
 
-  const queryValue = getCorrectQueryValue().replace(/\$2F/gi, "%2F")
+  const queryValue = getCorrectQueryValue().replace(/\$2F/gi, '%2F')
   const mapValue = queryField ? mapField : map
 
   return (

--- a/react/SearchContext.js
+++ b/react/SearchContext.js
@@ -6,6 +6,7 @@ import { useRuntime } from 'vtex.render-runtime'
 import SearchQuery from 'vtex.search-result/SearchQuery'
 
 import { initializeMap, SORT_OPTIONS } from './modules/search'
+import decodeForwardSlash from './utils/decodeForwardSlash'
 
 const DEFAULT_MAX_ITEMS_PER_PAGE = 10
 
@@ -81,7 +82,7 @@ const SearchContext = ({
     return query
   }
 
-  const queryValue = getCorrectQueryValue()
+  const queryValue = getCorrectQueryValue().replace(/\$2F/gi, "%2F")
   const mapValue = queryField ? mapField : map
 
   return (

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -71,9 +71,11 @@ const getPageEventName = (
 
 const getTitleTag = (titleTag: string, storeTitle: string, term?: string) => {
   return titleTag
-    ? `${titleTag} - ${storeTitle}`
+    ? `${decodeURIComponent(titleTag)} - ${storeTitle}`
     : term
-    ? `${capitalize(decodeURI(decodeForwardSlash(term)))} - ${storeTitle}`
+    ? `${capitalize(
+        decodeURIComponent(decodeForwardSlash(term))
+      )} - ${storeTitle}`
     : `${storeTitle}`
 }
 

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -24,6 +24,7 @@ import {
 } from './modules/searchMetadata'
 import { SearchQuery } from './modules/searchTypes'
 import { PixelEvent } from './typings/event'
+import decodeForwardSlash from './utils/decodeForwardSlash'
 
 const APP_LOCATOR = 'vtex.store'
 
@@ -72,7 +73,7 @@ const getTitleTag = (titleTag: string, storeTitle: string, term?: string) => {
   return titleTag
     ? `${titleTag} - ${storeTitle}`
     : term
-    ? `${capitalize(decodeURI(term))} - ${storeTitle}`
+    ? `${capitalize(decodeURI(decodeForwardSlash(term)))} - ${storeTitle}`
     : `${storeTitle}`
 }
 

--- a/react/utils/decodeForwardSlash.ts
+++ b/react/utils/decodeForwardSlash.ts
@@ -1,0 +1,12 @@
+/**
+ * Decode all "/" by using $2F instead of %2F
+ * Since "/" is a special character in URL, it can not be encoded normally,
+ * @export
+ * @param {string} str
+ * @returns {string}
+ */
+const decodeForwardSlash = (str: string) => {
+  return str.replace(/\$2F/gi, "/")
+}
+
+export default decodeForwardSlash

--- a/react/utils/decodeForwardSlash.ts
+++ b/react/utils/decodeForwardSlash.ts
@@ -6,7 +6,7 @@
  * @returns {string}
  */
 const decodeForwardSlash = (str: string) => {
-  return str.replace(/\$2F/gi, "/")
+  return str.replace(/\$2F/gi, '/')
 }
 
 export default decodeForwardSlash


### PR DESCRIPTION
#### What problem is this solving?

Currently, it is not possible to search for a term that contains "/" because it is not being encoded. For example, if you search for `3-48m/s br nl` the result will be the following

![image](https://user-images.githubusercontent.com/40380674/84977370-95d37100-b100-11ea-8826-70fb074b8d84.png)

It is not possible to encode the "/" with "%2F" because of [this](https://github.com/vtex/rewriter/blob/872e028b814de2ade81917dd73cb16f1394a29d1/node/utils/paths.ts#L21) function that will guarantee that no encoded term will pass.

My team and I decided to use another sequence of characters to encode it: `$2F`.

#### How to test it?

[Workspace](https://searchslashbug--storecomponents.myvtex.com/top$2fs?map=ft

#### Describe alternatives you've considered, if any.

I've tried really hard to keep the usual "code" for the `/`. But while   [this](https://github.com/vtex/rewriter/blob/872e028b814de2ade81917dd73cb16f1394a29d1/node/utils/paths.ts#L21) function is in the rewriter it will be impossible.

#### Related to / Depends on

https://github.com/vtex-apps/store-components/pull/797