### PR TITLE
Add Open Graph tags for 'store.home' and 'store.search' pages

### DIFF
--- a/react/HomeWrapper.js
+++ b/react/HomeWrapper.js
@@ -2,6 +2,7 @@ import React, { useMemo, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { useRuntime, canUseDOM } from 'vtex.render-runtime'
 import SearchAction from 'vtex.structured-data/SearchAction'
+import { HomeOpenGraph } from 'vtex.open-graph'
 
 import useDataPixel from './hooks/useDataPixel'
 
@@ -32,6 +33,7 @@ const HomeWrapper = ({ children }) => {
   return (
     <Fragment>
       <SearchAction searchTermPath={searchTermPath} />
+      <HomeOpenGraph />
       {children}
     </Fragment>
   )

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -12,6 +12,7 @@ import {
   LoadingContextProvider,
   canUseDOM,
 } from 'vtex.render-runtime'
+import { SearchOpenGraph } from 'vtex.open-graph'
 
 import { capitalize } from './modules/capitalize'
 import useDataPixel from './hooks/useDataPixel'
@@ -133,6 +134,11 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
     params.term
   )
 
+  const openGraphParams = {
+    title,
+    description: metaTagDescription,
+  }
+
   const pixelEvents = useMemo(() => {
     if (!searchQuery || !canUseDOM || !searchQuery.products) {
       return null
@@ -202,6 +208,7 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
           },
         ].filter(Boolean)}
       />
+      <SearchOpenGraph meta={openGraphParams} />
       <LoadingContextProvider value={loadingValue}>
         {React.cloneElement(children, props)}
       </LoadingContextProvider>


### PR DESCRIPTION
#### What problem is this solving?

We did not include meta tags for Open Graph (used by Facebook) to `store.home` and `store.search` pages.

These tags are useful when these pages are shared on Facebook since they're used to display rich previews, such as:

<img width="442" alt="Captura de Tela 2020-06-26 às 14 50 59" src="https://user-images.githubusercontent.com/27777263/85886420-756c7c00-b7bc-11ea-8e2b-d6afc0cf8f62.png">

#### How to test it?

1. Go to this [Workspace](https://victormiranda--storecomponents.myvtex.com/);
2. Inspect the page using your browser's dev tools and look for meta tags in the HTML, such as

<img width="881" alt="Captura de Tela 2020-06-26 às 14 53 32" src="https://user-images.githubusercontent.com/27777263/85887208-b913b580-b7bd-11ea-8112-1536a67830f1.png">

3. In the same workspace, go to a search page, such as [this one](https://victormiranda--storecomponents.myvtex.com/shoes?_q=Shoes&map=ft) and inspect the page's HTML looking for the same meta tags.

#### Screenshots or example usage:

This is the result of running Facebook's debugger **before** the change:

<img width="1041" alt="Captura de Tela 2020-06-26 às 15 05 13" src="https://user-images.githubusercontent.com/27777263/85887648-96ce6780-b7be-11ea-8502-1b2323f1d454.png">

(from https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fstoretheme.vtex.com%2F)

Then, **after** the change:

<img width="1029" alt="Captura de Tela 2020-06-26 às 15 07 27" src="https://user-images.githubusercontent.com/27777263/85887778-c7160600-b7be-11ea-8775-086f1b313d89.png">

For the `storecomponents` store, the actual rich preview did **not** change at all, but it could in different stores. 

<img width="547" alt="Captura de Tela 2020-06-26 às 15 10 16" src="https://user-images.githubusercontent.com/27777263/85888013-270cac80-b7bf-11ea-8cb7-4e58afb57180.png">

#### Related to / Depends on

Depends on: https://github.com/vtex-apps/open-graph/pull/11.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/idXzmUFOxEbFjeLG8f/giphy.gif)
