### PR TITLE
Add setting to disable Service Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Advanced setting to unregister the default Service Worker.
 
 ## [2.97.0] - 2020-06-29
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -88,10 +88,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "Configure your store's favicons"
       },
@@ -105,10 +102,16 @@
         "type": "object",
         "properties": {
           "enableOrderFormOptimization": {
-            "title": "Enable orderForm optimization",
+            "title": "orderForm optimization",
             "type": "boolean",
             "default": false,
-            "description": "This setting disables the legacy orderForm provider. More at: https://vtex.io/docs/recipes/store-management/enabling-order-form-optimization."
+            "description": "Disables the legacy orderForm provider. More at: https://vtex.io/docs/recipes/store-management/enabling-order-form-optimization."
+          },
+          "enableServiceWorker": {
+            "title": "Service Worker",
+            "type": "boolean",
+            "default": true,
+            "description": "Register the default Service Worker provided by VTEX."
           }
         }
       }

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-filename-extension */
 import React, { Fragment, useEffect } from 'react'
 import {
   canUseDOM,
@@ -101,6 +102,7 @@ const StoreWrapper = ({ children }) => {
     storeName,
     faviconLinks,
     enableOrderFormOptimization = false,
+    enableServiceWorker = true,
   } = settings
 
   const { canonicalHost, canonicalPath } = systemToCanonical(route)
@@ -148,9 +150,9 @@ const StoreWrapper = ({ children }) => {
         script={[
           supportsServiceWorker && {
             type: 'text/javascript',
-            src: `${rootPath}/pwa/workers/register.js${queryMatch}&scope=${encodeURIComponent(
-              rootPath
-            )}`,
+            src: `${rootPath}/pwa/workers/register.js${queryMatch}${
+              enableServiceWorker ? '' : '&__disableSW=true'
+            }&scope=${encodeURIComponent(rootPath)}`,
             defer: true,
           },
         ].filter(Boolean)}


### PR DESCRIPTION
#### What problem is this solving?

A website can only have one Service Worker registered and we provide one by default.

Some stores have another Service Worker provided by a third party service, like OneSignal. 

This setting makes it possible to disable ours, so third party Service Workers may function.

#### How to test it?

### Service Worker on. No changes were made to store settings.
https://brenoswon--storecomponents.myvtex.com/
![image](https://user-images.githubusercontent.com/284515/86373500-db904d80-bc59-11ea-838a-0bff6670e382.png)


### Service Worker off. Changes made in store settings.
https://brenoswoff--storecomponents.myvtex.com/
![image](https://user-images.githubusercontent.com/284515/86373456-cc110480-bc59-11ea-9507-72b4fd362833.png)

<img src="https://user-images.githubusercontent.com/284515/86369054-5191b600-bc54-11ea-9367-37190bc7f815.png" width="400" />

#### Describe alternatives you've considered, if any.

none

#### Related to / Depends on

Depends on https://github.com/vtex/pwa-graphql/pull/87

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
