### PR TITLE
use queryArgs instead of breadcrumb to get search metadata term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Uses `queryArgs` instead of `breadcrumb` to get the search metadata term.
+
 ## [2.99.1] - 2020-07-14
 ### Fixed
 - Redirect after login at the ProfileChallenge taking rootPath into consideration.

--- a/react/modules/searchMetadata.test.ts
+++ b/react/modules/searchMetadata.test.ts
@@ -141,6 +141,10 @@ test('should get the searched metadata', () => {
           children: [],
         },
       ],
+      queryArgs: {
+        query: 'Top',
+        map: 'ft'
+      }
     },
   }
 
@@ -178,6 +182,10 @@ test('should get the searched metadata without category', () => {
           children: [],
         },
       ],
+      queryArgs: {
+        query: 'Top',
+        map: 'ft',
+      }
     },
   }
 

--- a/react/modules/searchMetadata.test.ts
+++ b/react/modules/searchMetadata.test.ts
@@ -143,8 +143,8 @@ test('should get the searched metadata', () => {
       ],
       queryArgs: {
         query: 'Top',
-        map: 'ft'
-      }
+        map: 'ft',
+      },
     },
   }
 
@@ -185,7 +185,7 @@ test('should get the searched metadata without category', () => {
       queryArgs: {
         query: 'Top',
         map: 'ft',
-      }
+      },
     },
   }
 

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { endsWith } from 'ramda'
+import { zipObj } from 'ramda'
 
 import { SearchQueryData, CategoriesTrees } from './searchTypes'
 
@@ -76,14 +76,16 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
   if (
     !searchQuery ||
     !searchQuery.productSearch ||
-    !searchQuery.productSearch.breadcrumb
+    !searchQuery.facets ||
+    !searchQuery.facets.queryArgs
   ) {
     return
   }
 
-  const searchTerm = searchQuery.productSearch.breadcrumb.find(breadcrumb => {
-    return breadcrumb.href.includes('?map=') && endsWith('ft', breadcrumb.href)
-  })
+  const { query, map } = searchQuery.facets.queryArgs
+  const queryMap = zipObj(map.split(','), query.split('/'))
+
+  const searchTerm = queryMap.ft
 
   if (!searchTerm) {
     return
@@ -92,7 +94,7 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
   const department = getDepartment(searchQuery)
 
   return {
-    term: searchTerm.name,
+    term: decodeURIComponent(searchTerm),
     category: department ? { id: department.id, name: department.name } : null,
     results: searchQuery.productSearch.recordsFiltered,
     operator: searchQuery.productSearch.operator,

--- a/react/modules/searchTypes.ts
+++ b/react/modules/searchTypes.ts
@@ -41,6 +41,6 @@ export interface CategoriesTrees {
 }
 
 interface QueryArgs {
-  query: string;
-  map: string;
+  query: string
+  map: string
 }

--- a/react/modules/searchTypes.ts
+++ b/react/modules/searchTypes.ts
@@ -24,6 +24,7 @@ export interface SearchQueryData {
   }
   facets?: {
     categoriesTrees?: CategoriesTrees[]
+    queryArgs?: QueryArgs
   }
 }
 
@@ -37,4 +38,9 @@ export interface CategoriesTrees {
   name: string
   selected: boolean
   children?: CategoriesTrees[]
+}
+
+interface QueryArgs {
+  query: string;
+  map: string;
 }


### PR DESCRIPTION
#### What problem is this solving?

When building the search metadata, we are using the `productSearch.breadcrumb` to get the search term. The problem is that intelligent search uses `facets.breadcrumb` instead of `productSearch.breadcrumb`. I could add the facets' breadcrumb as a fallback, but I preferred to use the `productSearch.queryargs` field because I think it is more related to metadata info.

#### How to test it?

[Workspace](https://hiago--storecomponents.myvtex.com/top?_q=top&map=ft)

Access a full-text search and then type `window.pixelManagerEvents` on the console.

![image](https://user-images.githubusercontent.com/40380674/87441266-4b42f880-c5c9-11ea-8ad8-15da8f7d6893.png)

