### PR TITLE
add SearchPageState context to the SearchContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `SearchPageStateContext.Provider` and `SearchPageStateDispatch.Provider` to the `SearchContext`.
+
 ## [2.99.1] - 2020-07-14
 ### Fixed
 - Redirect after login at the ProfileChallenge taking rootPath into consideration.

--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,8 @@
     "vtex.product-review-interfaces": "1.x",
     "vtex.rich-text": "0.x",
     "vtex.native-types": "0.x",
-    "vtex.telemarketing": "2.x"
+    "vtex.telemarketing": "2.x",
+    "vtex.search-page-context": "0.x"
   },
   "settingsSchema": {
     "title": "VTEX Store",
@@ -88,10 +89,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "Configure your store's favicons"
       },

--- a/react/SearchContext.js
+++ b/react/SearchContext.js
@@ -4,6 +4,11 @@ import { path } from 'ramda'
 import React from 'react'
 import { useRuntime } from 'vtex.render-runtime'
 import SearchQuery from 'vtex.search-result/SearchQuery'
+import {
+  SearchPageStateContext,
+  SearchPageStateDispatch,
+  useSearchPageStateReducer,
+} from 'vtex.search-page-context/SearchPageContext'
 
 import { initializeMap, SORT_OPTIONS } from './modules/search'
 
@@ -84,58 +89,67 @@ const SearchContext = ({
   const queryValue = getCorrectQueryValue()
   const mapValue = queryField ? mapField : map
 
+  const [state, dispatch] = useSearchPageStateReducer({})
+
   return (
-    <SearchQuery
-      maxItemsPerPage={maxItemsPerPage}
-      query={queryValue}
-      map={mapValue}
-      orderBy={orderBy}
-      priceRange={priceRange}
-      hideUnavailableItems={hideUnavailableItems}
-      facetsBehavior={facetsBehavior}
-      pageQuery={pageQuery}
-      skusFilter={skusFilter}
-      simulationBehavior={simulationBehavior}
-      installmentCriteria={installmentCriteria}
-      operator={operator}
-      fuzzy={fuzzy}
-      searchState={searchState}
-      __unstableProductOriginVtex={__unstableProductOriginVtex}
-    >
-      {(searchQuery, extraParams) => {
-        return React.cloneElement(children, {
-          searchQuery: {
-            ...searchQuery,
-            // backwards-compatibility
-            data: {
-              ...(searchQuery.data || {}),
-              products: path(
-                ['data', 'productSearch', 'products'],
-                searchQuery
-              ),
-            },
-            facets: path(['data', 'facets'], searchQuery),
-            products: path(['data', 'productSearch', 'products'], searchQuery),
-            recordsFiltered: path(
-              ['data', 'productSearch', 'recordsFiltered'],
-              searchQuery
-            ),
-          },
-          searchContext: runtimePage,
-          pagesPath: nextTreePath,
-          map,
-          orderBy,
-          priceRange,
-          page: extraParams.page,
-          from: extraParams.from,
-          to: extraParams.to,
-          facetsLoading: extraParams.facetsLoading,
-          maxItemsPerPage,
-          // backwards-compatibility
-          rest,
-        })
-      }}
-    </SearchQuery>
+    <SearchPageStateContext.Provider value={state}>
+      <SearchPageStateDispatch.Provider value={dispatch}>
+        <SearchQuery
+          maxItemsPerPage={maxItemsPerPage}
+          query={queryValue}
+          map={mapValue}
+          orderBy={orderBy}
+          priceRange={priceRange}
+          hideUnavailableItems={hideUnavailableItems}
+          facetsBehavior={facetsBehavior}
+          pageQuery={pageQuery}
+          skusFilter={skusFilter}
+          simulationBehavior={simulationBehavior}
+          installmentCriteria={installmentCriteria}
+          operator={operator}
+          fuzzy={fuzzy}
+          searchState={searchState}
+          __unstableProductOriginVtex={__unstableProductOriginVtex}
+        >
+          {(searchQuery, extraParams) => {
+            return React.cloneElement(children, {
+              searchQuery: {
+                ...searchQuery,
+                // backwards-compatibility
+                data: {
+                  ...(searchQuery.data || {}),
+                  products: path(
+                    ['data', 'productSearch', 'products'],
+                    searchQuery
+                  ),
+                },
+                facets: path(['data', 'facets'], searchQuery),
+                products: path(
+                  ['data', 'productSearch', 'products'],
+                  searchQuery
+                ),
+                recordsFiltered: path(
+                  ['data', 'productSearch', 'recordsFiltered'],
+                  searchQuery
+                ),
+              },
+              searchContext: runtimePage,
+              pagesPath: nextTreePath,
+              map,
+              orderBy,
+              priceRange,
+              page: extraParams.page,
+              from: extraParams.from,
+              to: extraParams.to,
+              facetsLoading: extraParams.facetsLoading,
+              maxItemsPerPage,
+              // backwards-compatibility
+              rest,
+            })
+          }}
+        </SearchQuery>
+      </SearchPageStateDispatch.Provider>
+    </SearchPageStateContext.Provider>
   )
 }
 


### PR DESCRIPTION
#### What problem is this solving?

The `mobileLayout`is being reset during the filter selection.

This is happening because when the page change from `store.search#department` to `store.search#category,` for example, the `SearchResultLayout` is remounted, and then, the current `LayoutModeSwitcher` state is lost.

To solve this, I changed the `SearchPageStateContext.Provider/SearchPageStateDispatch.Provider` position from `SearchResultFlexible` to the `SearchContext`.

#### How to test it?

[Workspace](https://newfilternavigator--storecomponents.myvtex.com/kawasaki/top?_q=top&map=b,ft)

#### Screenshots or example usage:

##### Before:
![BAbbpGZRfv](https://user-images.githubusercontent.com/40380674/87701170-e5dc3c80-c76d-11ea-8506-938f96aaf659.gif)

##### After
![KvskSzj0Yd](https://user-images.githubusercontent.com/40380674/87702846-52f0d180-c770-11ea-90ab-e7dedaa42cea.gif)

#### Related to / Depends on

##### Related to

- https://github.com/vtex-apps/search-result/pull/394
- https://github.com/vtex-apps/search-page-context/pull/6