### PR TITLE
do product query with slug only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Do product query with slug only.
 
 ## [2.99.1] - 2020-07-14
 ### Fixed

--- a/react/ProductContext.js
+++ b/react/ProductContext.js
@@ -126,10 +126,6 @@ const catalogOptions = {
     variables: {
       slug: props.params.slug,
       skipCategoryTree: true,
-      identifier: {
-        field: 'id',
-        value: props.params.id || '',
-      },
     },
     errorPolicy: 'all',
   }),
@@ -140,10 +136,6 @@ const productBenefitsOptions = {
   options: props => ({
     variables: {
       slug: props.params.slug,
-      identifier: {
-        field: 'id',
-        value: props.params.id || '',
-      },
     },
     errorPolicy: 'all',
     ssr: false,
@@ -155,10 +147,6 @@ const categoryTreeOptions = {
   options: props => ({
     variables: {
       slug: props.params.slug,
-      identifier: {
-        field: 'id',
-        value: props.params.id || '',
-      },
     },
     errorPolicy: 'all',
     ssr: false,


### PR DESCRIPTION
#### What problem is this solving?

On render-server, we will not do the query with slug only. To avoid having to go to the pagetype API. This PR makes the change necessary for the server queries and the client queries, to match.

#### How to test it?

https://rewtes--storecomponents.myvtex.com/vintage-phone/p

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
