### PR TITLE
add queryArgs validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Do not push the `internalSiteSearchView` event while the `facets` query is not completed.
+
 ## [2.100.0] - 2020-08-11
 ### Added
 - `orderBy`, `page` and filter selection changes to trigger `pageInfo` event.

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -160,7 +160,12 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
   }
 
   const pixelEvents = useMemo(() => {
-    if (!searchQuery || !canUseDOM || !searchQuery.products) {
+    if (
+      !searchQuery ||
+      !canUseDOM ||
+      !searchQuery.products ||
+      !searchQuery.data?.facets?.queryArgs
+    ) {
       return null
     }
 


### PR DESCRIPTION
#### What problem is this solving?

The `internalSiteSearchView`event depends on the `facets` query, but sometimes, the message is sent before this query is completed. This PR makes sure that this event will only be sent when the query is completed.

#### How to test it?

[Workspace](https://hiago--xiaomimx.myvtex.com/redmi%20note%209?map=ft)

#### Screenshots or example usage:

##### Before fix
![bug](https://user-images.githubusercontent.com/40380674/89575386-11e65d00-d804-11ea-9e9e-b98e2fba6525.gif)

##### After fix
![fixed](https://user-images.githubusercontent.com/40380674/89575406-17dc3e00-d804-11ea-9acd-4b34828d3135.gif)

