### PR TITLE
Add orderBy and page to trigger pageinfo event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `orderBy`, `page` and filter selection changes to trigger `pageInfo` event.
 
 ## [2.99.2] - 2020-07-21
 

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -2,6 +2,7 @@ declare module 'vtex.render-runtime' {
   interface Runtime {
     account: string
     rootPath: string
+    query: Record<string, string>
     navigate: (args: NavigateArgs) => void
     getSettings(id: string): StoreSettings
     route: {


### PR DESCRIPTION
#### What problem is this solving?

To understand better the problem look at https://github.com/vtex-apps/store-discussion/issues/349

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->



**To test `Show More` and `orderBy` change**
[Als workspace](https://pixelsearch--alssports.myvtex.com/gloves?_q=gloves&map=ft)
1. [Workspace](https://pixelsearch--storecomponents.myvtex.com/apparel---accessories)
2. Check how many events are triggered already putting `pixelManagerEvents` into the console
3.  Make the action (change the `orderBy`  in the `SORT BY` dropdown or click show more
4. Check the size of events again, it should have a new `pageinfo` event triggered, it might have something else, but it doesn't matter
5. The `orderBy` or the `page` should be different if compared with the previous `pageinfo` event

To test filter changes just select a filter and check the events

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/400IbOQGqOWQgTLCvx/giphy.gif)
