### PR TITLE
New property `sellerName` in product pixel event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New property `sellerName` in product pixel event
 
 ## [2.100.1] - 2020-08-12
 

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -68,6 +68,7 @@ interface Image {
 interface Seller {
   commertialOffer: CommertialOffer
   sellerId: string
+  sellerName: string
 }
 
 interface CommertialOffer {
@@ -114,6 +115,7 @@ function getSkuProperties(item: SKU): SKUEvent {
       item.images && item.images.length > 0 ? item.images[0].imageUrl : '',
     sellers: item.sellers.map(seller => ({
       sellerId: seller.sellerId,
+      sellerName: seller.sellerName,
       commertialOffer: {
         Price: seller.commertialOffer.Price,
         ListPrice: seller.commertialOffer.ListPrice,


### PR DESCRIPTION
#### What problem is this solving?

We need the product's sellerName in a new event of our Pixel App.

#### How to test it?

[Workspace](https://gus--carrefourbr.myvtex.com/smartphone-samsung-galaxy-s10-128gb-branco-4g-tela-6-1-camera-tripla-16mp-selfie-10mp-dual-chip-android-9-0-5666287/p#product-info-anchor)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/49173685/90023355-0b376a00-dc8a-11ea-919d-6804bdc2ccc7.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![image](https://user-images.githubusercontent.com/49173685/90024149-edb6d000-dc8a-11ea-920d-68e39645e33e.png)
