### PR TITLE
Add new performance flags to the settings schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New performance settings (Enables CSS Concatenation, Enables Prefetch, and Enables Lazy Runtime).
 
 ## [2.101.1] - 2020-09-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- New performance settings (CSS Concatenation, Prefetch, and Lazy Runtime).
+- New performance settings.
 
 ## [2.101.1] - 2020-09-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- New performance settings (Enables CSS Concatenation, Enables Prefetch, and Enables Lazy Runtime).
+- New performance settings (CSS Concatenation, Prefetch, and Lazy Runtime).
 
 ## [2.101.1] - 2020-09-03
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -145,6 +145,12 @@
             "description": "Enables optimized submenu rendering, which improves performance. May cause style issues, test with caution after turning it on.",
             "type": "boolean",
             "default": false
+          },
+          "enableSearchRenderingOptimization": {
+            "title": "Enables lazy rendering of search results",
+            "description": "Enables optimized search results rendering, which improves performance. May cause style issues, test with caution after turning it on.",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -141,8 +141,8 @@
             "default": false
           },
           "enableMenuRenderingOptimization": {
-            "title": "Enables Menu Rendering Optimization",
-            "description": "Enables lazy rendering of submenu items.",
+            "title": "Enables lazy rendering of submenu items",
+            "description": "Enables optimized submenu rendering, which improves performance. May cause style issues, test with caution after turning it on.",
             "type": "boolean",
             "default": false
           }

--- a/manifest.json
+++ b/manifest.json
@@ -139,6 +139,12 @@
             "description": "Lazily loads the page's metadata.",
             "type": "boolean",
             "default": false
+          },
+          "enableMenuRenderingOptimization": {
+            "title": "Enables Menu Rendering Optimization",
+            "description": "Enables lazy rendering of submenu items.",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -121,6 +121,24 @@
             "type": "boolean",
             "default": false,
             "description": "Enables CSS optimizations that can improve performance and the Lighthouse score. Only affects the home page. May cause style inconsistencies, test with caution after turning it on."
+          },
+          "enableCSSConcatenation": {
+            "title": "Enables CSS Concatenation",
+            "description": "Concatenates a page's CSS in a single file for faster download.",
+            "type": "boolean",
+            "default": false
+          },
+          "enablePrefetch": {
+            "title": "Enables Prefetch",
+            "description": "Prefetches pages on mouse hover for faster navigation.",
+            "type": "boolean",
+            "default": false
+          },
+          "enableLazyRuntime": {
+            "title": "Enables Lazy Runtime",
+            "description": "Lazily loads the page's metadata.",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -147,8 +147,8 @@
             "default": false
           },
           "enableSearchRenderingOptimization": {
-            "title": "Enables lazy rendering of search results",
-            "description": "Enables optimized search results rendering, which improves performance. May cause style issues, test with caution after turning it on.",
+            "title": "Enables lazy rendering of search results and facets",
+            "description": "Enables optimized rendering of search results and facets, which improves performance. May cause style issues, test with caution after turning it on.",
             "type": "boolean",
             "default": false
           }


### PR DESCRIPTION
#### What problem is this solving?

We have new advanced features that increase the store's performance but should be turn on carefully.  

#### How to test it?

Link this app, open the Admin, go to CMS, and then to Store. Now, go to the Advanced tab and check if the new items (Enables CSS Concatenation, Enables Prefetch, and Enables Lazy Runtime) are visible.
You can check if the flags are working by turning them on or off, saving, and checking if the values are correct (go to your terminal and run `vtex settings get vtex.store`).

