### PR TITLE
Add new props to SearchContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `excludedPaymentSystems` and `includedPaymentSystems` props to `SearchContext` component.
 
 ## [2.102.0] - 2020-09-09
 ### Added

--- a/react/SearchContext.jsx
+++ b/react/SearchContext.jsx
@@ -23,6 +23,8 @@ const SearchContext = ({
   skusFilter,
   simulationBehavior,
   installmentCriteria,
+  excludedPaymentSystems,
+  includedPaymentSystems,
   query: {
     order: orderBy = orderByField || SORT_OPTIONS[0].value,
     page: pageQuery,
@@ -97,6 +99,8 @@ const SearchContext = ({
       skusFilter={skusFilter}
       simulationBehavior={simulationBehavior}
       installmentCriteria={installmentCriteria}
+      excludedPaymentSystems={excludedPaymentSystems}
+      includedPaymentSystems={includedPaymentSystems}
       operator={operator}
       fuzzy={fuzzy}
       searchState={searchState}
@@ -175,6 +179,8 @@ SearchContext.propTypes = {
   skusFilter: PropTypes.string,
   simulationBehavior: PropTypes.string,
   installmentCriteria: PropTypes.string,
+  excludedPaymentSystems: PropTypes.string,
+  includedPaymentSystems: PropTypes.string,
   __unstableProductOriginVtex: PropTypes.bool,
 }
 


### PR DESCRIPTION
#### What problem is this solving?

New props added to `SearchContext` component:

- `excludedPaymentSystems`
- `includedPaymentSystems`

These props enable users to pass these two arguments to the search query performed by `store.search` pages.

#### How to test it?

Go to this [workspace](https://victormiranda--storecomponents.myvtex.com/apparel---accessories/).

#### Related to / Depends on

Depends on https://github.com/vtex-apps/store-resources/pull/134.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/S5yqNNTQlEZfqQ7InC/giphy.gif)
