### PR TITLE
Feature/lazy search items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Passes down `lazyItemsRemaining` prop form SearchQuery to its children
+- Passes down `lazyItemsRemaining` prop from SearchQuery to its children
 
 ## [2.103.0] - 2020-09-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Passes down `lazyItemsRemaining` prop form SearchQuery to its children
 
 ## [2.103.0] - 2020-09-18
 ### Added

--- a/react/SearchContext.jsx
+++ b/react/SearchContext.jsx
@@ -137,6 +137,7 @@ const SearchContext = ({
           maxItemsPerPage,
           // backwards-compatibility
           rest,
+          lazyItemsRemaining: extraParams.lazyItemsRemaining,
         })
       }}
     </SearchQuery>


### PR DESCRIPTION
#### What problem is this solving?
#### What problem is this solving?
Limits initial search items if option `enableLazySearchQuery` is enabled. The remaining items are loaded lazily afterwards.

This reduces the initial query processing, both on the server and on the client, reduces the size of the cached page, initial data transfer, and consequently makes the initial render of the page much faster. By reducing the size of the cached page, it also may prevent the SSR from breaking due to the page being too large.

This is a simple two-step approach (limited loading first, load the rest soon); a more sophisticated approach might be done in the future.

This feature is enabled by enabling the setting `enableLazySearchQuery` on `vtex.store`

Related PRs:
https://github.com/vtex-apps/search-result/pull/429
https://github.com/vtex-apps/store/pull/488
https://github.com/vtex/render-server/pull/669

Initial query time comparison:
Before:
<img width="639" alt="Screen Shot 2020-09-17 at 15 20 32" src="https://user-images.githubusercontent.com/5691711/93511566-6ac40d80-f8f9-11ea-8381-88c17a8b8940.png">

After:
<img width="631" alt="Screen Shot 2020-09-17 at 15 20 28" src="https://user-images.githubusercontent.com/5691711/93511584-71eb1b80-f8f9-11ea-992f-2e96b2c4f16f.png">

Initial page weight:
Before (even without SSR working):
<img width="347" alt="Screen Shot 2020-09-17 at 15 22 33" src="https://user-images.githubusercontent.com/5691711/93511746-a9f25e80-f8f9-11ea-97bc-f47ccc595030.png">
(595kb gzipped/10.3mb ungzipped)

After:
<img width="345" alt="Screen Shot 2020-09-17 at 15 22 29" src="https://user-images.githubusercontent.com/5691711/93511762-b080d600-f8f9-11ea-9534-5c4663e531d5.png">
(335kb gzipped/4mb ungzipped)

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
https://www.carrefour.com.br/Celulares-Smartphones-e-Smartwatches/Smartphones?ak-testab=vtex&workspace=lbebberlazysearch5&v=01

There shouldn't be much of a visible difference from master (https://www.carrefour.com.br/Celulares-Smartphones-e-Smartwatches/Smartphones?ak-testab=vtex)

The main visible difference currently is that this fixes SSR, which is currently not working in master, so there might be some issues that are currently happening on server-side-rendered search pages (a temporary "Produto Indisponível"), but it is not related to this PR.

You might also face a spinner if you scroll down too soon, but the products should load soon enough.

There are also other things that slow down this page (too many installments, too many facets) which once fixed should also improve the experience.

In this workspace, all the apps for this feature are installed, but the setting is disabled. There shouldn't be any difference from the version in master https://www.carrefour.com.br/Celulares-Smartphones-e-Smartwatches/Smartphones?workspace=lbebberlazysearchdisabled

