### PR TITLE
Feature/enable perf settings default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Enable performance settings by default
 
 ## [2.105.0] - 2020-09-23
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -119,50 +119,50 @@
           "enableCriticalCSS": {
             "title": "Critical CSS Optimization",
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "Enables CSS optimizations that can improve performance and the Lighthouse score. Only affects the home page. May cause style inconsistencies, test with caution after turning it on."
           },
           "enableCSSConcatenation": {
             "title": "Enables CSS Concatenation",
             "description": "Concatenates a page's CSS in a single file for faster download.",
             "type": "boolean",
-            "default": false
+            "default": true
           },
           "enablePrefetch": {
             "title": "Enables Prefetch",
             "description": "Prefetches pages on mouse hover for faster navigation.",
             "type": "boolean",
-            "default": false
+            "default": true
           },
           "enableLazyRuntime": {
             "title": "Enables Lazy Runtime",
             "description": "Lazily loads the page's metadata.",
             "type": "boolean",
-            "default": false
+            "default": true
           },
           "enableMenuRenderingOptimization": {
             "title": "Enables lazy rendering of submenu items",
             "description": "Enables optimized submenu rendering, which improves performance. May cause style issues, test with caution after turning it on.",
             "type": "boolean",
-            "default": false
+            "default": true
           },
           "enableSearchRenderingOptimization": {
             "title": "Enables lazy rendering of search results and facets",
             "description": "Enables optimized rendering of search results and facets, which improves performance. May cause style issues, test with caution after turning it on.",
             "type": "boolean",
-            "default": false
+            "default": true
           },
           "enableAsyncScripts": {
             "title": "Enables loading scripts asynchronously",
             "description": "Start processing scripts sooner by asynchronously loading and executing them.",
             "type": "boolean",
-            "default": false
+            "default": true
           },
           "enableConcurrentMode": {
             "title": "Enables React Concurrent Mode",
             "description": "Help the store to stay responsive and adjust to the user’s device capabilities and network speed.",
             "type": "boolean",
-            "default": false
+            "default": true
           }
         }
       }


### PR DESCRIPTION
#### What problem is this solving?
Enable performance settings by default

A script has been run on current store to set their current values, so this update shouldn't affect them, only new accounts.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
