### PR TITLE
Fix dependency route leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Chore
+- Launch a new version with the latest builder-hub to prevent dependency route leaking.
 
 ## [2.108.0] - 2020-10-22
 ### Added


### PR DESCRIPTION
#### What problem is this solving?

Dependency route leaking.
More details: https://github.com/vtex/builder-hub/pull/991 https://github.com/vtex/colossus/pull/305

#### How to test it?

Unfortunately, the `vtex deps update` does not work anymore. But there is a version released using the new builder-hub here: https://brunoh--storecomponents.myvtex.com/ and it works fine.