### PR TITLE
Prevent SSR crash when product data is loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+-  Prevent SSR crash when product data is loading.
 
 ## [2.108.1] - 2020-10-27
 ### Chore

--- a/manifest.json
+++ b/manifest.json
@@ -88,10 +88,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "Configure your store's favicons"
       },
@@ -167,6 +164,12 @@
           "enableFiltersFetchOptimization": {
             "title": "Enables fetching filters partially",
             "description": "Improves search pages' performance by fetching only the 10 first facets of every filter, adding a button to show the rest. May cause issues when going to a page with facets selected, especially on search-resolver v0. Test with caution after turning it on",
+            "type": "boolean",
+            "default": false
+          },
+          "enableFullSSROnProduct": {
+            "title": "Enables executing all graphQL queries on the product page",
+            "description": "It helps when a product page needs to fetch extra data to render components above the fold. Just turn it on if your product page really needs it, otherwise it will be a deoptimization.",
             "type": "boolean",
             "default": false
           }

--- a/manifest.json
+++ b/manifest.json
@@ -168,7 +168,7 @@
             "default": false
           },
           "enableFullSSROnProduct": {
-            "title": "Enables executing all graphQL queries on the product page",
+            "title": "Enables executing all GraphQL queries on the product page",
             "description": "It helps when a product page needs to fetch extra data to render components above the fold. Just turn it on if your product page really needs it, otherwise it will be a deoptimization.",
             "type": "boolean",
             "default": false

--- a/react/ProductWrapper.js
+++ b/react/ProductWrapper.js
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types'
 import React, { useMemo, Fragment } from 'react'
-import { LoadingContextProvider } from 'vtex.render-runtime'
+import {
+  LoadingContextProvider,
+  canUseDOM,
+  useRuntime,
+} from 'vtex.render-runtime'
 import { ProductOpenGraph } from 'vtex.open-graph'
 import useProduct from 'vtex.product-context/useProduct'
 import ProductContextProvider from 'vtex.product-context/ProductContextProvider'
@@ -35,6 +39,8 @@ const ProductWrapper = ({
   children,
   ...props
 }) => {
+  const { getSettings } = useRuntime()
+  const { enableFullSSROnProduct } = getSettings('vtex.store')
   const childrenProps = useMemo(
     () => ({
       productQuery,
@@ -53,12 +59,17 @@ const ProductWrapper = ({
     [loading, hasProductData]
   )
 
+  const SSRLoading =
+    loadingValue.isParentLoading && enableFullSSROnProduct && !canUseDOM ? (
+      <Fragment />
+    ) : null
+
   return (
     <WrapperContainer className="vtex-product-context-provider">
       <ProductContextProvider query={query} product={product}>
         <Content loading={loading} childrenProps={childrenProps}>
           <LoadingContextProvider value={loadingValue}>
-            {children}
+            {SSRLoading || children}
           </LoadingContextProvider>
         </Content>
       </ProductContextProvider>

--- a/react/ProductWrapper.js
+++ b/react/ProductWrapper.js
@@ -59,17 +59,15 @@ const ProductWrapper = ({
     [loading, hasProductData]
   )
 
-  const SSRLoading =
-    loadingValue.isParentLoading && enableFullSSROnProduct && !canUseDOM ? (
-      <Fragment />
-    ) : null
+  const isSSRLoading =
+    loadingValue.isParentLoading && enableFullSSROnProduct && !canUseDOM
 
   return (
     <WrapperContainer className="vtex-product-context-provider">
       <ProductContextProvider query={query} product={product}>
         <Content loading={loading} childrenProps={childrenProps}>
           <LoadingContextProvider value={loadingValue}>
-            {SSRLoading || children}
+            {isSSRLoading ? <Fragment /> : children}
           </LoadingContextProvider>
         </Content>
       </ProductContextProvider>


### PR DESCRIPTION
#### What problem is this solving?

There is a new feature flag called `enableFullSSROnProduct` (https://github.com/vtex/render-server/pull/691) to make the product page run in the render-ssr, allowing other graphql queries to be executed besides the product one.

Unfortunately many custom components do not care about the loading state, and apollo, even with the product data already restored in its memory cache (from render-server), render at first with no data and loading=true, making our `userProduct` hook return a `null` product and crashing any component that doesn't handle it well.

#### How to test it?

`vtex.render-server` and this `vtex.store` are linked here, with `enableFullSSROnProduct=true`:
https://pdpssrdev--dzarm.myvtex.com/calca-jeans-super-skinny-com-elastano-cintura-media-zu5v1asn/p

and here is the error in the same scenario but without this `vtex.store` linked:
https://pdpssrdevx--dzarm.myvtex.com/calca-jeans-super-skinny-com-elastano-cintura-media-zu5v1asn/p?

#### Related to / Depends on

The `enableFullSSROnProduct` flag behaviour depends on the render-server PR, but it should not block this PR from being merged.