### PR TITLE
Fix title tag with percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `titleTag` with percentage.
 
 ## [2.109.1] - 2020-11-05
 ### Changed

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -71,9 +71,14 @@ const getPageEventName = (
 }
 
 const getTitleTag = (titleTag: string, storeTitle: string, term?: string) => {
-  return titleTag
-    ? `${decodeURIComponent(titleTag)} - ${storeTitle}`
-    : term
+  if (titleTag) {
+    try {
+      return `${decodeURIComponent(titleTag)} - ${storeTitle}`
+    } catch {
+      return `${titleTag} - ${storeTitle}`
+    }
+  }
+  return term
     ? `${capitalize(
         decodeURIComponent(decodeForwardSlash(term))
       )} - ${storeTitle}`


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
When the title tag had a percentage symbol (`%`) an error was occurring when trying to run decodeURIComponent(titleTag)

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Before](https://raissateste--acctglobal.myvtex.com/141?map=productClusterIds)

[Workspace](https://testedecodeuri--acctglobal.myvtex.com/141?map=productClusterIds)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
