### PR TITLE
Update default 'orderBy' option to 'OrderByDefault'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Default `orderBy` value to `OrderByDefault`, which follows the behavior defined by the Catalog.
+- Default `orderBy` value to an empty string. This way the result will follow the behavior defined by the API.
 
 ## [2.108.1] - 2020-10-27
 ### Chore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Default `orderBy` value to `OrderByDefault`, which follows the behavior defined by the Catalog.
 
 ## [2.108.1] - 2020-10-27
 ### Chore

--- a/react/modules/search.js
+++ b/react/modules/search.js
@@ -1,6 +1,6 @@
 export const SORT_OPTIONS = [
   {
-    value: 'OrderByDefault',
+    value: '',
     label: 'store/ordenation.default',
   },
   {

--- a/react/modules/search.js
+++ b/react/modules/search.js
@@ -1,5 +1,9 @@
 export const SORT_OPTIONS = [
   {
+    value: 'OrderByDefault',
+    label: 'store/ordenation.default',
+  },
+  {
     value: 'OrderByScoreDESC',
     label: 'store/ordenation.relevance',
   },


### PR DESCRIPTION
#### What problem is this solving?

Our default `orderBy` would not follow the default behavior from the Search API, as we always set the default to `OrderByScoreDesc`. A big problem that came up is that it was not possible to just present the products in the same order as they were placed inside their collections.

This new `OrderByDefault` is the one that is interpreted by our search resolvers as "don't send any orderBy and let the API handle that".

#### How to test it?

Go to this [Workspace](https://victormiranda--cosmetics1.myvtex.com/6008?map=productClusterIds).

#### Screenshots or example usage:

<img width="252" alt="Screen Shot 2020-10-28 at 16 32 11" src="https://user-images.githubusercontent.com/27777263/97487090-26d21880-193b-11eb-9e5d-113f541372a9.png">

#### Depends on

- https://github.com/vtex-apps/search-result/pull/442

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![another one](https://media.giphy.com/media/l0HlQ7LRalQqdWfao/giphy.gif)
