### PR TITLE
Add category property on SearchContext to return category ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `category` property on `SearchContext` to return category ID
 
 ## [2.109.0] - 2020-10-28
 ### Added

--- a/react/SearchContext.jsx
+++ b/react/SearchContext.jsx
@@ -43,6 +43,7 @@ const SearchContext = ({
     page: runtimePage,
     query: runtimeQuery,
     route: {
+      params: { id: runtimeId },
       queryString: { map: renderMap },
     },
   } = useRuntime()
@@ -107,6 +108,8 @@ const SearchContext = ({
       __unstableProductOriginVtex={__unstableProductOriginVtex}
     >
       {(searchQuery, extraParams) => {
+
+        searchQuery.category = runtimeId
         return React.cloneElement(children, {
           searchQuery: {
             ...searchQuery,

--- a/react/SearchContext.jsx
+++ b/react/SearchContext.jsx
@@ -43,7 +43,6 @@ const SearchContext = ({
     page: runtimePage,
     query: runtimeQuery,
     route: {
-      params: { id: runtimeId },
       queryString: { map: renderMap },
     },
   } = useRuntime()
@@ -89,6 +88,7 @@ const SearchContext = ({
 
   return (
     <SearchQuery
+      category={params.id}
       maxItemsPerPage={maxItemsPerPage}
       query={queryValue}
       map={mapValue}
@@ -108,8 +108,6 @@ const SearchContext = ({
       __unstableProductOriginVtex={__unstableProductOriginVtex}
     >
       {(searchQuery, extraParams) => {
-
-        searchQuery.category = runtimeId
         return React.cloneElement(children, {
           searchQuery: {
             ...searchQuery,
@@ -133,6 +131,7 @@ const SearchContext = ({
           map,
           orderBy,
           priceRange,
+          category: params.id,
           page: extraParams.page,
           from: extraParams.from,
           to: extraParams.to,


### PR DESCRIPTION
#### What problem is this solving?

Added `category` to `productSearch: values` on `productSearchV3`

#### How to test it?

`category` field is returning empty on `search-resolver` response. 

[Workspace]https://ricardofreitas--iocea.myvtex.com/moda-masculina/bermudas

#### Screenshots or example usage:

screenshot of productSearch args return on search-resolver app without PR changes
![image](https://user-images.githubusercontent.com/26003016/98120915-59c16280-1e8d-11eb-80cd-e1d6b0616d2e.png)

screenshot of productSearch args return on search-resolver app with PR changes
![image](https://user-images.githubusercontent.com/26003016/98121054-8aa19780-1e8d-11eb-8425-053a4a0b92b8.png)


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

https://github.com/vtex-apps/store-resources/pull/139

https://github.com/vtex-apps/search-result/pull/446


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
