### PR TITLE
Bring back order by "Relevance" as the default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Default `orderBy` value is now to order items by "Relevance", which now means products will follow the same ordering logic defined by the Search API.
 
 ## [2.109.2] - 2020-11-05
 ### Fixed

--- a/react/modules/search.js
+++ b/react/modules/search.js
@@ -1,10 +1,6 @@
 export const SORT_OPTIONS = [
   {
     value: '',
-    label: 'store/ordenation.default',
-  },
-  {
-    value: 'OrderByScoreDESC',
     label: 'store/ordenation.relevance',
   },
   {


### PR DESCRIPTION
#### What problem is this solving?

We're removing the `Default` sorting option introduced by #496 in favor of changing the way the `Relevance` ordering works. It will now follow the same behavior defined by the Search API.

#### How to test it?

Go to [Workspace](https://victormiranda--cosmetics1.myvtex.com/6008?map=productClusterIds) and check that the orderBy is set to `Relevance`, and the products are ordered the same way they are [here](https://cosmetics1.vtexcommercestable.com.br/6008?map=productClusterIds).

#### Related to / Depends on

Depends on: https://github.com/vtex-apps/search-result/pull/452.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
