### PR TITLE
Removes store-indexer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removes store-indexer dependency
 
 ## [2.110.0] - 2020-12-11
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,6 @@
     "docs": "0.x"
   },
   "dependencies": {
-    "vtex.store-indexer": "0.x",
     "vtex.store-resources": "0.x",
     "vtex.store-graphql": "2.x",
     "vtex.store-header": "2.x",


### PR DESCRIPTION
#### What problem is this solving?

Remos store-indexer as a default store dependency since it is only used for multi-binding stores.

#### How to test it?


#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
