### PR TITLE
Use searchState of the sessionStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Use `searchState` of the `sessionStorage` when it exists.
+
 ## [2.110.0] - 2020-12-11
 ### Added
 - PDP critical CSS settings on schema.

--- a/react/SearchContext.jsx
+++ b/react/SearchContext.jsx
@@ -85,6 +85,10 @@ const SearchContext = ({
 
   const queryValue = getCorrectQueryValue().replace(/\$2F/gi, '%2F')
   const mapValue = queryField ? mapField : map
+  const state =
+    (typeof sessionStorage !== 'undefined' &&
+      sessionStorage.getItem('searchState')) ||
+    searchState
 
   return (
     <SearchQuery
@@ -103,7 +107,7 @@ const SearchContext = ({
       includedPaymentSystems={includedPaymentSystems}
       operator={operator}
       fuzzy={fuzzy}
-      searchState={searchState}
+      searchState={state}
       __unstableProductOriginVtex={__unstableProductOriginVtex}
     >
       {(searchQuery, extraParams) => {


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://searchstate--iocea.myvtex.com/moda-feminina/blusas)
- set the `searchState` of the `sessionStorage`. 
ex: `sessionStorage.setItem('searchState', '{"rcs":"1","sessionId":"1","userId":"1"}')`
- reload the page and check if the url contains the `searchState` that you set.
- you can also check if the `FilterNavigator` has the state:

![image](https://user-images.githubusercontent.com/20840671/106049286-bb781e00-60c4-11eb-94d0-30508d278915.png)


#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
