### PR TITLE
Add CustomContext prop in page wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Possibility to add a custom global context in page wrappers.
 
 ## [2.110.0] - 2020-12-11
 ### Added

--- a/react/ProductWrapper.js
+++ b/react/ProductWrapper.js
@@ -36,6 +36,7 @@ const ProductWrapper = ({
   productQuery,
   productQuery: { product, loading } = {},
   query,
+  CustomContext,
   children,
   ...props
 }) => {
@@ -62,12 +63,16 @@ const ProductWrapper = ({
   const isSSRLoading =
     loadingValue.isParentLoading && enableFullSSROnProduct && !canUseDOM
 
+  const CustomContextElement = CustomContext || Fragment
+
   return (
     <WrapperContainer className="vtex-product-context-provider">
       <ProductContextProvider query={query} product={product}>
         <Content loading={loading} childrenProps={childrenProps}>
           <LoadingContextProvider value={loadingValue}>
-            {isSSRLoading ? <Fragment /> : children}
+            <CustomContextElement>
+              {isSSRLoading ? <Fragment /> : children}
+            </CustomContextElement>
           </LoadingContextProvider>
         </Content>
       </ProductContextProvider>
@@ -81,6 +86,7 @@ ProductWrapper.propTypes = {
   children: PropTypes.node,
   /* URL query params */
   query: PropTypes.object,
+  CustomContext: PropTypes.any,
 }
 
 export default ProductWrapper

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   FC,
   ReactElement,
+  ComponentType,
 } from 'react'
 import {
   Helmet,
@@ -134,6 +135,7 @@ interface SearchWrapperProps {
   searchQuery: SearchQuery
   orderBy?: string
   to?: number
+  CustomContext?: ComponentType
 }
 
 const SearchWrapper: FC<SearchWrapperProps> = props => {
@@ -147,6 +149,7 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
         searchMetadata: { titleTag = '', metaTagDescription = '' } = {},
       } = {},
     } = {},
+    CustomContext,
     children,
   } = props
   const {
@@ -229,6 +232,8 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
     }
   }, [loading])
 
+  const CustomContextElement = CustomContext ?? Fragment
+
   return (
     <Fragment>
       <Helmet
@@ -247,7 +252,9 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
       <ProductListStructuredData products={searchQuery.products} />
       <SearchOpenGraph meta={openGraphParams} />
       <LoadingContextProvider value={loadingValue}>
-        {React.cloneElement(children, props)}
+        <CustomContextElement>
+          {React.cloneElement(children, props)}
+        </CustomContextElement>
       </LoadingContextProvider>
     </Fragment>
   )

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -62,7 +62,7 @@ const useFavicons = faviconLinks => {
   })
 }
 
-const StoreWrapper = ({ children }) => {
+const StoreWrapper = ({ children, CustomContext }) => {
   const {
     amp,
     culture: { country, locale, currency },
@@ -118,12 +118,14 @@ const StoreWrapper = ({ children }) => {
 
   const parsedFavicons = useFavicons(faviconLinks)
 
+  const CustomContextElement = CustomContext || Fragment
+
   const content = (
     <OrderQueueProvider>
       <OrderFormProviderCheckout>
         <OrderItemsProvider>
           <WrapperContainer className="vtex-store__template bg-base">
-            {children}
+            <CustomContextElement>{children}</CustomContextElement>
           </WrapperContainer>
         </OrderItemsProvider>
       </OrderFormProviderCheckout>
@@ -202,6 +204,7 @@ const StoreWrapper = ({ children }) => {
 
 StoreWrapper.propTypes = {
   children: PropTypes.element,
+  CustomContext: PropTypes.any,
 }
 
 export default StoreWrapper


### PR DESCRIPTION
#### What problem is this solving?

Make it possible to create custom global context in pages.

## How to use?

### Step 1: Create a React component that accepts `children`.

1. Create a React component in the root directory of the `react` folder
Example:

```tsx
/* MyCustomContext.js */
import React from 'react'

import MyContext from './modules/MyContext'

function MyCustomContext({ children }) {
  return <MyContext.Provider value={123}>{children}</MyContext.Provider>
}

export default MyCustomContext
```

2. Create an interface for it in the `store/interfaces.json` file.
Example:

```json
{
  "my-custom-context": {
    "component": "MyCustomContext",
    "composition": "children"
  }
}
```

### Step 2: Use this new block as a slot of a page wrapper

There are 3 page wrappers available:

Wrapper | Pages available | Contexts available
---|---|---
`storeWrapper` | All pages | [`useOrderForm`](https://github.com/vtex-apps/order-manager), [`useOrderItems`](https://github.com/vtex-apps/order-items)
`productWrapper` | Product pages | [`useOrderForm`](https://github.com/vtex-apps/order-manager), [`useOrderItems`](https://github.com/vtex-apps/order-items), and [`useProduct`](https://github.com/vtex-apps/product-context)
`searchWrapper` | Search pages | [`useOrderForm`](https://github.com/vtex-apps/order-manager), [`useOrderItems`](https://github.com/vtex-apps/order-items), [`useSearchPage`](https://github.com/vtex-apps/search-page-context), [`useSearchPageState`](https://github.com/vtex-apps/search-page-context), and [`useSearchPageStateDispatch`](useSearchPageStateDispatch).

Example of usage:

1. Simple usage:
```diff
 {
   "store.product": {
     "children": [
       // PDP blocks
       // ...
     ]
   },
+  "productWrapper": {
+    "props": {
+      "CustomContext": "my-custom-context"
+    }
+  }
 }
```

2. Varying context based on page

You can use the `parent` feature to change the block based on page. That's similar to the solution of a custom header described here: https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-customizing-the-header-and-footer-blocks-by-page

```diff
 {
   "store.home": {
+    "parent": {
+      "storeWrapper": "storeWrapper#home"
+    },
     "children": [
       // Home blocks
       // ...
     ]
   },
+  "storeWrapper#home": {
+    "props": {
+      "CustomContext": "my-custom-context"
+    }
+  }
 }
```
```diff
 {
   "store.product": {
+   "parent": {
+      "storeWrapper": "storeWrapper#product"
+    },
     "children": [
       // PDP blocks
       // ...
     ]
   },
+  "storeWrapper#product": {
+    "props": {
+      "CustomContext": "my-custom-context"
+    }
+  }
 }
```

3. Using more than one page wrapper

```diff
 {
   "store.product": {
     "children": [
       // PDP blocks
       // ...
     ]
   },
+  "storeWrapper": {
+    "props": {
+      "CustomContext": "my-custom-context"
+    }
+  },
+  "productWrapper": {
+    "props": {
+      "CustomContext": "my-custom-context"
+    }
+  }
 }
```

4. You can mix it all together

Why not? 🤷 

```diff
 {
   "store.product": {
+    "parent": {
+      "storeWrapper": "storeWrapper#custompdpcontext",
+      "productWrapper": "productWrapper#custompdpcontext"
+    },
     "children": [
       // PDP blocks
       // ...
     ]
   },
+  "storeWrapper#custompdpcontext": {
+    "props": {
+      "CustomContext": "my-custom-context"
+    }
+  },
+  "productWrapper#custompdpcontext": {
+    "props": {
+      "CustomContext": "my-custom-context"
+    }
+  }
 }
```

Remember that `my-custom-context` is a normal block, so you can also pass props to it.

Example:

```diff
 {
   "store.product": {
     "children": [
       // PDP blocks
       // ...
     ]
   },
   "productWrapper": {
     "props": {
       "CustomContext": "my-custom-context"
     }
   },
+  "my-custom-context": {
+    "props": {
+      "exampleProp": "abc"
+    }
+  }
 }
```

#### How to test it?

https://context--storecomponents.myvtex.com/blouse-with-knot/p?skuId=2000544

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

Depends on https://github.com/vtex-apps/render-runtime/pull/601

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/lPFN3EqbaCEMXt0Y6Q/giphy.gif)
