### PR TITLE
fix IS URLs order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Intelligent search URLs now have the following order: `/[category hierarchy/alphabetically]/[brand alphabetically]/[specs alphabetically]`
+
 ## [2.111.0] - 2021-02-02
 ### Added
 - Possibility to add a custom global context in page wrappers.

--- a/react/__tests__/navigation.test.js
+++ b/react/__tests__/navigation.test.js
@@ -28,6 +28,17 @@ describe('Navigation route modifier', () => {
 
     expect(result).toEqual({ path: expectedPath, query: expectedQuery })
   })
+  it('intelligent search queries should have the following order: /[category hierarchy/alphabetically]/[brand alphabetically]/[specs alphabetically]', () => {
+    const path = '/departmentvalue/categoryvalue1/categoryvalue2'
+    const query =
+      'map=specificationFilter,category-2,category-2,brand,category-1,brand,&query=/specvalue/categoryvalue2/categoryvalue1/brandvalue2/departmentvalue/brandvalue1'
+    const expectedPath = path.toLocaleLowerCase()
+    const expectedQuery =
+      'map=category-1,category-2,category-2,brand,brand,specificationFilter&query=/departmentvalue/categoryvalue1/categoryvalue2/brandvalue1/brandvalue2/specvalue'
+    const result = normalizeNavigation({ path, query })
+
+    expect(result).toEqual({ path: expectedPath, query: expectedQuery })
+  })
   it('should preserve case for new routes pattern', () => {
     const path = '/foo/bar/nice_Bar'
     const expectedPath = '/foo/bar/nice_Bar'

--- a/react/utils/navigation.js
+++ b/react/utils/navigation.js
@@ -7,6 +7,7 @@ const SPEC_FILTER = 'specificationFilter'
 const MAP_CATEGORY_CHAR = 'c'
 const MAP_VALUES_SEP = ','
 const PATH_SEPARATOR = '/'
+const INTELLIGENT_SEARCH_BRAND = 'brand'
 
 const isLegacySearchFormat = (pathSegments, map) => {
   if (!map) {
@@ -29,8 +30,36 @@ const categoriesInSequence = mapValues => {
 const queryMapComparator = (tuple1, tuple2) => {
   const [, specFilterVal1] = tuple1 && tuple1[0].split(`${SPEC_FILTER}_`)
   const [, specFilterVal2] = tuple2 && tuple2[0].split(`${SPEC_FILTER}_`)
-  const facetName1 = tuple1[1]
-  const facetName2 = tuple2[1]
+  const [facetName1, facetValue1] = tuple1
+  const [facetName2, facetValue2] = tuple2
+
+  const intelligentSearchCategoryRegex = /category-[0-9]+/
+  const isISCategory1 = intelligentSearchCategoryRegex.test(facetName1)
+  const isISCategory2 = intelligentSearchCategoryRegex.test(facetName2)
+  const isISBrand1 = facetName1 === INTELLIGENT_SEARCH_BRAND
+  const isISBrand2 = facetName2 === INTELLIGENT_SEARCH_BRAND
+
+  // Makes the URL in the IS have the following order:
+  // /[category hierarchy/alphabetically]/[brand alphabetically]/[specs alphabetically]
+  // Example: category-1/category-2/brand/spec1/spec2
+  if (isISCategory1 && !isISCategory2) {
+    return -1
+  }
+  if (isISCategory2 && !isISCategory1) {
+    return 1
+  }
+  if (isISCategory1 && isISCategory2) {
+    return (
+      facetName1.localeCompare(facetName2) ||
+      facetValue1.localeCompare(facetValue2)
+    )
+  }
+  if (isISBrand1 && !isISBrand2) {
+    return -1
+  }
+  if (isISBrand2 && !isISBrand1) {
+    return 1
+  }
 
   const considerSpecificationFilter =
     specFilterVal1 &&
@@ -41,8 +70,8 @@ const queryMapComparator = (tuple1, tuple2) => {
   return considerSpecificationFilter
     ? Number(specFilterVal1) -
         Number(specFilterVal2) +
-        facetName1.localeCompare(facetName2)
-    : facetName1.localeCompare(facetName2)
+        facetValue1.localeCompare(facetValue2)
+    : facetValue1.localeCompare(facetValue2)
 }
 
 const normalizeQueryMap = (pathSegments, mapSegments) => {


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
Since Intelligent Search doesn't have the same facet name as SOLR, the URL order is not following the category/brand hierarchy. This PR fixes this problem.

#### How to test it?
- Go to the workspace
- Click on the `Cafetiere` category
- Check the breadcrumb order. On the broken workspace, the category comes first. On the fixed workspace, the department comes first

[Broken workspace](https://morphyrichardsro.myvtex.com/electrocasnice)
[Fixed workspace](https://hiago--morphyrichardsro.myvtex.com/electrocasnice)

#### Screenshots or example usage:

Broken:
![image](https://user-images.githubusercontent.com/40380674/106763412-8fedba00-6615-11eb-84df-04a3a0b21467.png)


Fixed:
![image](https://user-images.githubusercontent.com/40380674/106763367-849a8e80-6615-11eb-85f4-3ea482e46f09.png)

