### PR TITLE
add categorytreebehavior to the facets query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `__unstableCategoryTreeBehavior` prop to the `SearchContext`.
+
 ## [2.113.0] - 2021-03-17
 
 ### Changed

--- a/react/SearchContext.jsx
+++ b/react/SearchContext.jsx
@@ -20,6 +20,7 @@ const SearchContext = ({
   orderByField,
   hideUnavailableItems,
   facetsBehavior = 'Static',
+  __unstableCategoryTreeBehavior = 'default',
   skusFilter,
   simulationBehavior,
   installmentCriteria,
@@ -99,6 +100,7 @@ const SearchContext = ({
       priceRange={priceRange}
       hideUnavailableItems={hideUnavailableItems}
       facetsBehavior={facetsBehavior}
+      categoryTreeBehavior={__unstableCategoryTreeBehavior}
       pageQuery={pageQuery}
       skusFilter={skusFilter}
       simulationBehavior={simulationBehavior}
@@ -181,6 +183,7 @@ SearchContext.propTypes = {
   maxItemsPerPage: PropTypes.number,
   hideUnavailableItems: PropTypes.bool,
   facetsBehavior: PropTypes.string,
+  __unstableCategoryTreeBehavior: PropTypes.string,
   skusFilter: PropTypes.string,
   simulationBehavior: PropTypes.string,
   installmentCriteria: PropTypes.string,


### PR DESCRIPTION
#### What problem is this solving?

Add the `__unstableCategoryBehavior` to the `store.search` props. We will use this to control when the categoryTree will show up. The 0.x version doesn't have the support and the 1.x is still in alpha with this feature. That's why I'm using `__unstable`.

#### How to test it?

[workspace](https://categorytreebehavior--storecomponents.myvtex.com/apparel---accessories/)


#### Related to / Depends on

- https://github.com/vtex-apps/search-graphql/pull/106
- https://github.com/vtex-apps/store-resources/pull/150
