### PR TITLE
Service Worker Merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Service Worker Merged implementation adapted.
 
 ## [2.115.0] - 2021-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Changed
+### Changed
 - Service Worker Merged implementation adapted.
 
 ## [2.115.0] - 2021-03-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
 - Service Worker Merged implementation adapted.
 
 ## [2.115.0] - 2021-03-30

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -152,7 +152,7 @@ const StoreWrapper = ({ children, CustomContext }) => {
         script={[
           supportsServiceWorker && {
             type: 'text/javascript',
-            src: `${rootPath}/service-worker/register.js${queryMatch}${
+            src: `${rootPath}/register.js${queryMatch}${
               enableServiceWorker ? '' : '&__disableSW=true'
             }&scope=${encodeURIComponent(rootPath)}`,
             defer: true,

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -152,7 +152,7 @@ const StoreWrapper = ({ children, CustomContext }) => {
         script={[
           supportsServiceWorker && {
             type: 'text/javascript',
-            src: `${rootPath}/serviceWorkerRegister.js${queryMatch}${
+            src: `${rootPath}/service-worker/register.js${queryMatch}${
               enableServiceWorker ? '' : '&__disableSW=true'
             }&scope=${encodeURIComponent(rootPath)}`,
             defer: true,

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -152,7 +152,7 @@ const StoreWrapper = ({ children, CustomContext }) => {
         script={[
           supportsServiceWorker && {
             type: 'text/javascript',
-            src: `${rootPath}/pwa/workers/register.js${queryMatch}${
+            src: `${rootPath}/serviceWorkerRegister.js${queryMatch}${
               enableServiceWorker ? '' : '&__disableSW=true'
             }&scope=${encodeURIComponent(rootPath)}`,
             defer: true,


### PR DESCRIPTION
Added support for Merged Service Worker

#### What problem is this solving?

This PR adds support for the new scheme of Service Workers used in the Store app. It allows the usage of more than one Service Worker within a scope, using the feature implemented on [service-worker-graphql](https://github.com/vtex/service-worker-graphql/blob/feat/working-sw/node/middlewares/getMergedSW.ts#L102)

#### How to test it?

Once store is fully charged, check if a Service Worker called `serviceWorkerMerged.js` is successfully registered on the main scope of the page.

Workspace: ariangc

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/21017429/112053244-1ad13800-8b22-11eb-8e3c-7fba9b40cbd1.png)

#### Related to / Depends on

- [service-worker-graphql](https://github.com/vtex/service-worker-graphql/)
- [onesignal](https://github.com/vtex-apps/onesignal)
- [pwa-graphql](https://github.com/vtex/pwa-graphql)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/JfSB6Bbyq5AaJc7xZE/giphy.gif)
