### PR TITLE
Add sellerDefault field to productView event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `sellerDefault` field for `productView` event.
 
 ## [2.114.0] - 2021-03-25
 

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -69,6 +69,7 @@ interface Seller {
   commertialOffer: CommertialOffer
   sellerId: string
   sellerName: string
+  sellerDefault: boolean
 }
 
 interface CommertialOffer {
@@ -116,6 +117,7 @@ function getSkuProperties(item: SKU): SKUEvent {
     sellers: item.sellers.map(seller => ({
       sellerId: seller.sellerId,
       sellerName: seller.sellerName,
+      sellerDefault: seller.sellerDefault,
       commertialOffer: {
         Price: seller.commertialOffer.Price,
         ListPrice: seller.commertialOffer.ListPrice,


### PR DESCRIPTION
#### What problem is this solving?

Provide the field `sellerDefault` to pixel events so we can change this:
https://github.com/vtex-apps/google-tag-manager/blob/2049f0db20c72eb63b9c96851958de731934a49f/react/modules/enhancedEcommerceEvents.ts#L21

#### How to test it?

https://brenovtex--elektra.myvtex.com/multifuncional-hp-inktank-415-1500286269/p

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![image](https://user-images.githubusercontent.com/284515/112553004-790c4e00-8da2-11eb-926d-ca076bfb68ee.png)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

Depends on https://github.com/vtex-apps/store-resources/pull/151

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
