### PR TITLE
Adding list to productView GTM event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `list` to `productView` GTM event (`productDetail`) 
 
 ## [2.116.0] - 2021-04-05
 ### Changed

--- a/react/ProductWrapper.js
+++ b/react/ProductWrapper.js
@@ -54,7 +54,7 @@ const ProductWrapper = ({
 
   const hasProductData = !!product
 
-  const { listName } = query
+  const { listName } = query || {}
 
   const loadingValue = useMemo(
     () => ({

--- a/react/ProductWrapper.js
+++ b/react/ProductWrapper.js
@@ -13,11 +13,12 @@ import { Product as ProductStructuredData } from 'vtex.structured-data'
 import WrapperContainer from './components/WrapperContainer'
 import ProductTitleAndPixel from './components/ProductTitleAndPixel'
 
-const Content = ({ loading, children, childrenProps }) => {
+const Content = ({ listName, loading, children, childrenProps }) => {
   const { product, selectedItem } = useProduct()
   return (
     <Fragment>
       <ProductTitleAndPixel
+        listName={listName}
         product={product}
         selectedItem={selectedItem}
         loading={loading}
@@ -53,6 +54,8 @@ const ProductWrapper = ({
 
   const hasProductData = !!product
 
+  const { listName } = query
+
   const loadingValue = useMemo(
     () => ({
       isParentLoading: loading || !hasProductData,
@@ -68,7 +71,11 @@ const ProductWrapper = ({
   return (
     <WrapperContainer className="vtex-product-context-provider">
       <ProductContextProvider query={query} product={product}>
-        <Content loading={loading} childrenProps={childrenProps}>
+        <Content
+          listName={listName}
+          loading={loading}
+          childrenProps={childrenProps}
+        >
           <LoadingContextProvider value={loadingValue}>
             <CustomContextElement>
               {isSSRLoading ? <Fragment /> : children}

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -127,11 +127,19 @@ function getSkuProperties(item: SKU): SKUEvent {
   }
 }
 
-function useProductEvents(
-  product: Product,
-  selectedItem: SKU,
+interface UseProductEventsParams {
+  product: Product
+  selectedItem: SKU
   loading: boolean
-) {
+  listName?: string
+}
+
+function useProductEvents({
+  product,
+  selectedItem,
+  loading,
+  listName,
+}: UseProductEventsParams) {
   const productEvents = useMemo(() => {
     const hasCategoryTree = Boolean(product?.categoryTree?.length)
 
@@ -158,9 +166,10 @@ function useProductEvents(
       {
         event: 'productView',
         product: eventProduct,
+        list: listName,
       },
     ]
-  }, [product, selectedItem])
+  }, [product, selectedItem, listName])
 
   // When linkText or selectedItem changes, it will trigger the productEvents
   const pixelCacheKey = `${product?.linkText}${selectedItem?.itemId}`
@@ -187,6 +196,7 @@ function useTitle(product: Product) {
 }
 
 interface Props {
+  listName?: string
   product: Product
   selectedItem: SKU
   loading: boolean
@@ -196,6 +206,7 @@ const ProductTitleAndPixel: FC<Props> = ({
   product,
   selectedItem,
   loading,
+  listName,
 }) => {
   const { metaTagDescription = undefined } = product || {}
   const title = useTitle(product)
@@ -207,7 +218,7 @@ const ProductTitleAndPixel: FC<Props> = ({
     cacheKey: pixelCacheKey,
   })
   usePageInfo(title, product, loading)
-  useProductEvents(product, selectedItem, loading)
+  useProductEvents({ product, selectedItem, loading, listName })
 
   return (
     <Helmet


### PR DESCRIPTION
#### What problem is this solving?

This PR makes the product page compatible with the new major of the GTM app. It receives the listName via the querystring and sends it to the `productView` event.

#### How to test it?

[Workspace](https://icarogtm--storecomponents.myvtex.com/)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/bcbPzkSCytDH2/giphy.gif)