### PR TITLE
Chore/disable b2b flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Disable B2B behavior flag.
 
 ## [2.116.0] - 2021-04-05
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -205,12 +205,42 @@
           }
         }
       }
+    },
+    "dependencies": {
+      "requiresAuthorization": {
+        "oneOf": [
+          {
+            "properties": {
+              "requiresAuthorization": {
+                "enum": [false]
+              }
+            }
+          },
+          {
+            "properties": {
+              "requiresAuthorization": {
+                "enum": [true]
+              },
+              "b2bEnabled": {
+                "title": "admin/store.b2benabled.title",
+                "type": "string",
+                "format": "read-only",
+                "default": "true"
+              }
+            }
+          }
+        ]
+      }
     }
   },
   "settingsUiSchema": {
     "requiresAuthorization": {
-      "ui:disabled": true
-    }
+      "ui:widget": "hidden"
+    },
+    "b2bEnabled": {
+      "ui:disabled": "true"
+    },
+    "ui:order": ["storeName", "requiresAuthorization", "b2bEnabled", "*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -88,10 +88,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "admin/store.faviconLinks.description"
       },
@@ -208,6 +205,11 @@
           }
         }
       }
+    }
+  },
+  "settingsUiSchema": {
+    "requiresAuthorization": {
+      "ui:disabled": true
     }
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"


### PR DESCRIPTION
#### What problem is this solving?

The "enables B2B behavior" flag is dangerous as it makes our GraphQL and navigation requests not cacheable. It was necessary because the user's token is required when fetching data from private sales channels. However some months ago we managed to create a new solution based on the segment cookie.

We are deprecating this flag now. The first step is to disable it.

#### How to test it?

Beta version installed here: https://brunoh--b2bstore.myvtex.com/admin/app/cms/store

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/2726345/117841862-c3af3000-b253-11eb-8cb9-34f3e1730fe5.png)
