### PR TITLE
Improving SEO on search pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Canonical url for search pages now includes page number to improve SEO
+
+### Added
+- `<link>` elements pointing to previous and next pages to improve SEO
 
 ## [2.117.0] - 2021-05-13
 ### Changed

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -126,7 +126,7 @@ function getCanonicalMaybeWithPage(canonicalLink: string, page: number) {
   return canonicalWithPage
 }
 
-function getHelmetLink(
+export function getHelmetLink(
   canonicalLink: string | null,
   page: number,
   rel: 'canonical' | 'prev' | 'next'

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -21,20 +21,12 @@ import OrderFormProvider from './components/OrderFormProvider'
 import NetworkStatusToast from './components/NetworkStatusToast'
 import WrapperContainer from './components/WrapperContainer'
 import { normalizeNavigation } from './utils/navigation'
+import { useCanonicalLink } from './hooks/useCanonicalLink'
 
 const APP_LOCATOR = 'vtex.store'
 const CONTENT_TYPE = 'text/html; charset=utf-8'
 const META_ROBOTS = 'index, follow'
 const MOBILE_SCALING = 'width=device-width, initial-scale=1'
-
-const systemToCanonical = ({ canonicalPath }) => {
-  const canonicalHost =
-    window.__hostname__ || (window.location && window.location.hostname)
-  return {
-    canonicalPath,
-    canonicalHost,
-  }
-}
 
 const isSiteEditorIframe = () => {
   try {
@@ -105,16 +97,12 @@ const StoreWrapper = ({ children, CustomContext }) => {
     enableServiceWorker = true,
   } = settings
 
-  const { canonicalHost, canonicalPath } = systemToCanonical(route)
   const description = (metaTags && metaTags.description) || metaTagDescription
   const title = pageTitle || titleTag
 
   const [queryMatch] = route.path.match(/\?.*/) || ['?']
 
-  const canonicalLink =
-    canonicalHost &&
-    canonicalPath &&
-    `https://${canonicalHost}${rootPath}${canonicalPath}`
+  const canonicalLink = useCanonicalLink()
 
   const parsedFavicons = useFavicons(faviconLinks)
 

--- a/react/__tests__/SearchWrapper.test.ts
+++ b/react/__tests__/SearchWrapper.test.ts
@@ -1,0 +1,48 @@
+import { getHelmetLink } from '../SearchWrapper'
+
+describe('getHelmetLink function', () => {
+  it('should return null if no canonical is provided', () => {
+    const result = getHelmetLink(null, 1, 'canonical')
+
+    // Cannot generate meta links if there's no canonical link to use
+    expect(result).toBeNull()
+  })
+
+  it('should return null if resulting page is less than 1', () => {
+    const canonicalLink = 'https://storetheme.vtex.com/apparel---accessories/'
+
+    const canonicalLinkResult = getHelmetLink(canonicalLink, -1, 'canonical')
+    const nextLinkResult = getHelmetLink(canonicalLink, -1, 'next')
+    const prevLinkResult = getHelmetLink(canonicalLink, 1, 'prev')
+
+    expect(canonicalLinkResult).toBeNull()
+    expect(nextLinkResult).toBeNull()
+    expect(prevLinkResult).toBeNull()
+  })
+
+  it('should not return page number if page is equal to 1', () => {
+    const canonicalLink = 'https://storetheme.vtex.com/apparel---accessories/'
+
+    const canonicalLinkResult = getHelmetLink(canonicalLink, 1, 'canonical')
+    const nextLinkResult = getHelmetLink(canonicalLink, 0, 'next')
+    const prevLinkResult = getHelmetLink(canonicalLink, 2, 'prev')
+
+    expect(canonicalLinkResult).toHaveProperty('href', encodeURI(canonicalLink))
+    expect(nextLinkResult).toHaveProperty('href', encodeURI(canonicalLink))
+    expect(prevLinkResult).toHaveProperty('href', encodeURI(canonicalLink))
+  })
+
+  it('should return canonical link with page querystring appended to it', () => {
+    const canonicalLink = 'https://storetheme.vtex.com/apparel---accessories/'
+
+    const canonicalLinkResult = getHelmetLink(canonicalLink, 2, 'canonical')
+    const nextLinkResult = getHelmetLink(canonicalLink, 1, 'next')
+    const prevLinkResult = getHelmetLink(canonicalLink, 3, 'prev')
+
+    const expectedResult = encodeURI(`${canonicalLink}?page=2`)
+
+    expect(canonicalLinkResult).toHaveProperty('href', expectedResult)
+    expect(nextLinkResult).toHaveProperty('href', expectedResult)
+    expect(prevLinkResult).toHaveProperty('href', expectedResult)
+  })
+})

--- a/react/hooks/useCanonicalLink.ts
+++ b/react/hooks/useCanonicalLink.ts
@@ -1,0 +1,17 @@
+import { RuntimeWithRoute, useRuntime } from 'vtex.render-runtime'
+
+export function useCanonicalLink() {
+  const { route, rootPath = '' } = useRuntime() as RuntimeWithRoute
+  const { canonicalPath } = route
+
+  const canonicalHost =
+    window.__hostname__ || (window.location && window.location.hostname)
+
+  if (!canonicalHost || !canonicalPath) {
+    return null
+  }
+
+  const canonicalLink = `https://${canonicalHost}${rootPath}${canonicalPath}`
+
+  return canonicalLink
+}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,3 +1,4 @@
 interface Window extends Window {
   dataLayer: any[]
+  __hostname__: string | undefined
 }

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -10,6 +10,20 @@ declare module 'vtex.render-runtime' {
     }
   }
 
+  interface RuntimeWithRoute extends Runtime {
+    route: {
+      routeId: string
+      title?: string
+      metaTags?: MetaTagsParams
+      canonicalPath?: string
+    }
+  }
+
+  interface MetaTagsParams {
+    description: string
+    keywords: string[]
+  }
+
   interface NavigateArgs {
     fallbackToWindowLocation: boolean
     to: string


### PR DESCRIPTION
#### What problem is this solving?

This PR adds tags for previous and next pages on the search page that have them and fixes the canonical URLs by including the page number on them.

These fixes work better on non Full Text search pages such as brand or category pages, but that is not a problem since FT pages are not indexed.

#### How to test it?

[Workspace](https://icarosearchseo--storecomponents.myvtex.com/apparel---accessories/)

#### Screenshots or example usage:

![Screen Shot 2021-05-25 at 17 52 11](https://user-images.githubusercontent.com/8127610/119566961-1f180c80-bd82-11eb-9a6c-e2fdc827b0fd.png)
![Screen Shot 2021-05-25 at 17 52 56](https://user-images.githubusercontent.com/8127610/119567010-28a17480-bd82-11eb-9c80-ce5d4055bd7d.png)

#### Related to / Depends on

Related to [https://github.com/vtex-apps/search-result/pull/516](https://github.com/vtex-apps/search-result/pull/516)
#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/0qiwSa0SwH8DTNjQyR/giphy-downsized.gif)
