### PR TITLE
Changing product page to get listName via route params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Now gets `listName` from params, not from query string
 
 ## [2.119.0] - 2021-06-09
 ### Added

--- a/react/ProductWrapper.js
+++ b/react/ProductWrapper.js
@@ -33,7 +33,7 @@ const Content = ({ listName, loading, children, childrenProps }) => {
 }
 
 const ProductWrapper = ({
-  params: { slug },
+  params: { slug, __listName: listName },
   productQuery,
   productQuery: { product, loading } = {},
   query,
@@ -53,8 +53,6 @@ const ProductWrapper = ({
   )
 
   const hasProductData = !!product
-
-  const { listName } = query || {}
 
   const loadingValue = useMemo(
     () => ({


### PR DESCRIPTION
#### What problem is this solving?

The product page now should receive the `listName` via runtime params. This is better than the URL approach because it doesn't conflict with other tracking methods and for the fact that if someone shares the URL with someone, now it won't incorrectly assume that the user that clicked the link came from the same shelf the user that shared the link did.

#### How to test it?

Click any shelf or search result. It should take you to the product page. Type `dataLayer` into your console, and check for the last `productDetail` event. It should have the name of the list you clicked somewhere there. The default listName for shelves is `List of products`.

[Workspace](https://icarogtm--storecomponents.myvtex.com/)

#### Related to / Depends on

Related to [https://github.com/vtex-apps/product-summary/pull/318](https://github.com/vtex-apps/product-summary/pull/318)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/s4kpsTSwoiFCU/giphy.gif)
