### PR TITLE
feat: add Twitter meta tags to product page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,8 @@
     "vtex.product-review-interfaces": "1.x",
     "vtex.rich-text": "0.x",
     "vtex.native-types": "0.x",
-    "vtex.telemarketing": "2.x"
+    "vtex.telemarketing": "2.x",
+    "vtex.twitter-meta-tags": "0.x"
   },
   "settingsSchema": {
     "title": "admin/store.title",
@@ -88,10 +89,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "admin/store.faviconLinks.description"
       },
@@ -99,6 +97,23 @@
         "title": "admin/store.searchTermPath.title",
         "type": "string",
         "description": "admin/store.searchTermPath.description"
+      },
+      "includeTwitterMetaTags": {
+        "title": "Include Twitter meta tags",
+        "type": "boolean"
+      },
+      "twitterUsername": {
+        "title": "Twitter username",
+        "description": "The username your business uses on Twitter, for example: VTEXcommerce. (Do not include the @ sign)",
+        "type": "string"
+      },
+      "twitterCard": {
+        "title": "Twitter Card",
+        "description": "Please choose the type for the Twitter Card",
+        "type": "string",
+        "default": "summary",
+        "enum": ["photo", "summary", "summary_large_image"],
+        "enumNames": ["Photo", "Summary", "Summmary Large Image"]
       },
       "advancedSettings": {
         "title": "admin/store.advancedSettings.title",
@@ -215,18 +230,14 @@
           {
             "properties": {
               "requiresAuthorization": {
-                "enum": [
-                  false
-                ]
+                "enum": [false]
               }
             }
           },
           {
             "properties": {
               "requiresAuthorization": {
-                "enum": [
-                  true
-                ]
+                "enum": [true]
               },
               "b2bEnabled": {
                 "title": "admin/store.b2benabled.title",
@@ -247,12 +258,7 @@
     "b2bEnabled": {
       "ui:disabled": "true"
     },
-    "ui:order": [
-      "storeName",
-      "requiresAuthorization",
-      "b2bEnabled",
-      "*"
-    ]
+    "ui:order": ["storeName", "requiresAuthorization", "b2bEnabled", "*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/ProductWrapper.js
+++ b/react/ProductWrapper.js
@@ -6,6 +6,7 @@ import {
   useRuntime,
 } from 'vtex.render-runtime'
 import { ProductOpenGraph } from 'vtex.open-graph'
+import { TwitterMetaTags } from 'vtex.twitter-meta-tags'
 import useProduct from 'vtex.product-context/useProduct'
 import ProductContextProvider from 'vtex.product-context/ProductContextProvider'
 import { Product as ProductStructuredData } from 'vtex.structured-data'
@@ -24,6 +25,9 @@ const Content = ({ listName, loading, children, childrenProps }) => {
         loading={loading}
       />
       {product && <ProductOpenGraph />}
+
+      {product && <TwitterMetaTags />}
+
       {product && selectedItem && (
         <ProductStructuredData product={product} selectedItem={selectedItem} />
       )}


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the possibility to add Twitter meta tags to a store's Product Page. The tags can be included by toggling the option in `Admin > CMS > Store`

The meta tags that are being added are the following:
```
<meta name=“twitter:card” content={ "photo" | "summary" | "summary_large_image" } />
<meta name=“twitter:site” content={ twitterUsername } />
<meta name=“twitter:title” content={ productName } />
<meta name=“twitter:description” content={ productDescription } />
<meta name=“twitter:image” content={ imageUrl } />
<meta name=“twitter:url” content={ productPageUrl } />
```

The settings added to the store's settingsSchema for this app can be found [here](https://github.com/vtex-apps/store/compare/master...edyespinal:feat/twitter-meta-tags?expand=1#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743R100-R117) and the logic to add the `meta tags` can be found [here](https://github.com/vtex-apps/store/compare/master...edyespinal:feat/twitter-meta-tags?expand=1#diff-83c3f01ece1766a45f47cb00077fe7463304cc1ff0934f13499739bb5762cc62R29).

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
The Twitter Meta Tags and the Store apps are linked in [this workspace](https://twitter--vtexspain.myvtex.com/).
To test it, make sure the `includeTwitterMetaTags` toggle is checked and add the Twitter Username and Twitter Card text fields are filled. Then visit any product page and look check for the Meta Tags that are being added.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![Screenshot 2021-07-28 at 16 21 28](https://user-images.githubusercontent.com/17585823/127339671-cb9693c9-be72-44d3-bf49-469f25d2c354.png)
![Screenshot 2021-07-28 at 16 23 10](https://user-images.githubusercontent.com/17585823/127339699-a053a4f8-50e1-4e1c-985e-2792cf00b068.png)

