### PR TITLE
Feat/settings by binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Handle app settings by bindings.
+
 ## [2.120.1] - 2021-08-31
 ### Fixed
 - Canonical url on search pages that explicitly need `map` query strings declarations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,8 @@ This project has the following capabilities:
 - Dispatch view events to analytics tools. 
 - Define the necessary interfaces and routes of the store.
 
+For use cases where the store has several bindings, the app can handle different values for each binding, by selecting the flag `Enable configuration by binding` in the application settings.
+
 ## Release schedule
 
 | Release |       Status        | Initial Release | Maintenance LTS Start | End-of-life | Store Compatibility |

--- a/manifest.json
+++ b/manifest.json
@@ -39,6 +39,7 @@
   "settingsSchema": {
     "title": "admin/store.title",
     "type": "object",
+    "bindingBounded": true,
     "properties": {
       "storeName": {
         "title": "admin/store.storeName.title",
@@ -88,10 +89,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "admin/store.faviconLinks.description"
       },
@@ -215,18 +213,14 @@
           {
             "properties": {
               "requiresAuthorization": {
-                "enum": [
-                  false
-                ]
+                "enum": [false]
               }
             }
           },
           {
             "properties": {
               "requiresAuthorization": {
-                "enum": [
-                  true
-                ]
+                "enum": [true]
               },
               "b2bEnabled": {
                 "title": "admin/store.b2benabled.title",
@@ -247,12 +241,7 @@
     "b2bEnabled": {
       "ui:disabled": "true"
     },
-    "ui:order": [
-      "storeName",
-      "requiresAuthorization",
-      "b2bEnabled",
-      "*"
-    ]
+    "ui:order": ["storeName", "requiresAuthorization", "b2bEnabled", "*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
Costumers that have more than one binding per account cannot have different values for the store configuration. It can be harmful for SEO when different bindings are for different languages. This PR allows customers to have settings binding bounded.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->


This [workspace](https://storesettings--ametllerorigen.myvtex.com/admin/apps/vtex.store@2.120.1/setup/) has the branched linked on and setting for different bindings. The flag brings a checkout option to create settings based on bindings.

The default behavior for the flag `bindingBounded` is off, so the customers have to opt in for it. There wouldn't be any breaking changes.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

_Default view_

<img width="1433" alt="Screen Shot 2021-09-16 at 11 13 30 AM" src="https://user-images.githubusercontent.com/38737958/133601521-55e1ab4c-3ded-48a6-90cd-6b768a239fd5.png">

_Flag selected_

<img width="1421" alt="Screen Shot 2021-09-16 at 1 08 55 PM" src="https://user-images.githubusercontent.com/38737958/133601818-7d5e6842-24e7-4703-a76f-27556a6f7efa.png">

