### PR TITLE
Product specifications on productView event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Pass product specifications on `productView` event
 
 ## [2.120.1] - 2021-08-31
 ### Fixed

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -25,6 +25,12 @@ interface Product {
   metaTagDescription: string
   productReference: string
   items: SKU[]
+  properties: ProductProperties[]
+}
+
+interface ProductProperties {
+  name: string
+  values: string[]
 }
 
 interface ProductViewEvent {
@@ -40,6 +46,7 @@ interface ProductViewEvent {
   productName: string
   items: SKUEvent[]
   selectedSku: SKUEvent
+  properties: ProductProperties[]
 }
 
 interface Category {
@@ -161,6 +168,7 @@ function useProductEvents({
       productName: product.productName,
       items: product.items.map(getSkuProperties),
       selectedSku: getSkuProperties(selectedItem),
+      properties: product.properties
     }
 
     return [


### PR DESCRIPTION
#### What problem is this solving?
Hello. I just added product specifications on productView Event.

[Workspace Here](https://events--melimeloparis.myvtex.com/)


![specs](https://user-images.githubusercontent.com/43498488/137925008-bc5c74e9-cf2f-4be1-911c-73851b26aa5a.jpg)

