### PR TITLE
PER-2976: Fix metadata when categoriesTree does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Category and department metadata when `categoriesTree` doesn't exist.
+
 ## [2.120.1] - 2021-08-31
 ### Fixed
 - Canonical url on search pages that explicitly need `map` query strings declarations.

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -1,14 +1,27 @@
 // eslint-disable-next-line no-restricted-imports
 import { zipObj } from 'ramda'
 
-import { SearchQueryData, CategoriesTrees } from './searchTypes'
+import { SearchQueryData, CategoriesTrees, Facets } from './searchTypes'
+
+const getDepartmentFromSpecificationFilters = (facets?: Facets) => {
+  if (!facets?.queryArgs?.map.split(',').includes('c')) {
+    return
+  }
+
+  const departmentFilter = facets.specificationFilters?.find(specFilter => {
+    return specFilter.facets?.[0].key === 'category-1'
+  })
+
+  return departmentFilter?.facets?.find(facet => facet.selected)
+}
 
 const getDepartment = (searchQuery: SearchQueryData) => {
-  return (
-    searchQuery.facets &&
-    searchQuery.facets.categoriesTrees &&
-    searchQuery.facets.categoriesTrees.find(department => department.selected)
-  )
+  if (searchQuery.facets?.categoriesTrees?.length) {
+    return searchQuery.facets.categoriesTrees.find(
+      department => department.selected
+    )
+  }
+  return getDepartmentFromSpecificationFilters(searchQuery.facets)
 }
 
 export const getDepartmentMetadata = (searchQuery?: SearchQueryData) => {
@@ -32,14 +45,32 @@ export const getDepartmentMetadata = (searchQuery?: SearchQueryData) => {
   }
 }
 
-const getLastCategory = (category: CategoriesTrees): CategoriesTrees => {
+const getCategoryFromSpecificationFilters = (facets?: Facets) => {
+  const totalCategories =
+    facets?.queryArgs?.map.split(',').filter((key: string) => key === 'c')
+      .length ?? 0
+
+  if (totalCategories <= 1) {
+    return
+  }
+  const categoryFilter = facets?.specificationFilters?.find(specFilter => {
+    return specFilter.facets?.[0].key === 'category-2'
+  })
+
+  return categoryFilter?.facets?.find(facet => facet.selected)
+}
+
+const getLastCategory = (
+  category: CategoriesTrees,
+  facets?: Facets
+): CategoriesTrees => {
   const selectedCategory =
     category.children &&
     category.children.length > 0 &&
     category.children.find(currCategory => currCategory.selected)
 
   if (!selectedCategory) {
-    return category
+    return getCategoryFromSpecificationFilters(facets) ?? category
   }
 
   return getLastCategory(selectedCategory)
@@ -60,7 +91,7 @@ export const getCategoryMetadata = (searchQuery?: SearchQueryData) => {
     return
   }
 
-  const category = getLastCategory(department)
+  const category = getLastCategory(department, searchQuery.facets)
 
   if (category === department) {
     return

--- a/react/modules/searchTypes.ts
+++ b/react/modules/searchTypes.ts
@@ -22,10 +22,21 @@ export interface SearchQueryData {
       misspelled: boolean
     }
   }
-  facets?: {
-    categoriesTrees?: CategoriesTrees[]
-    queryArgs?: QueryArgs
-  }
+  facets?: Facets
+}
+
+export interface Facets {
+  categoriesTrees?: CategoriesTrees[]
+  queryArgs?: QueryArgs
+  specificationFilters?: SpecificationFilter[]
+}
+
+interface SpecificationFilter {
+  facets?: any[]
+  hidden: boolean
+  name: string
+  quantity: number
+  type: string
 }
 
 export interface Breadcrumb {


### PR DESCRIPTION
#### What problem is this solving?
When the category tree doesn't exist, the category and department metadata were not fill

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta3--storecomponents.myvtex.com/apparel-accessories?map=category-1)

#### Screenshots or example usage:
Before: note that in the pixel's `pageInfo` event the category and department were empty
![image](https://user-images.githubusercontent.com/20840671/139731517-83248144-d6cb-406d-b227-d54ec127dba1.png)

After:
![image](https://user-images.githubusercontent.com/20840671/139731703-6d4a69cf-e550-4972-a9d6-f00222a3b818.png)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
