### PR TITLE
Fixing search query updates due to URL decoding not being executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Search's `query` is now URL decoded whenever possible. This avoids unnecessary updates on the page when the query contain spaces coded as `%20`, for example, and makes "Show More" functionality work correctly.
 
 ## [2.120.1] - 2021-08-31
 ### Fixed

--- a/react/SearchContext.jsx
+++ b/react/SearchContext.jsx
@@ -69,19 +69,28 @@ const SearchContext = ({
     .replace(/\/\//g, '/') // This cleans some bad cases of two // on some terms.
 
   const getCorrectQueryValue = () => {
+    let queryValue = query
+
     // Checks if this is on the format of preventRouteChange and get the correct data
     if (areFieldsFromQueryStringValid) {
-      return fieldsFromQueryString.queryField
+      queryValue = fieldsFromQueryString.queryField
     }
+
     // Normal query format, without preventRouteChange
-    if (queryField) {
-      return queryField
+    else if (queryField) {
+      queryValue = queryField
     }
+
     // Legacy search
-    if (rest && rest.length > 0) {
-      return `${query}/${rest.replace(',', '/')}`
+    else if (rest && rest.length > 0) {
+      queryValue = `${query}/${rest.replace(',', '/')}`
     }
-    return query
+
+    try {
+      return decodeURIComponent(queryValue)
+    } catch {
+      return queryValue
+    }
   }
 
   const queryValue = getCorrectQueryValue()


### PR DESCRIPTION
#### What problem is this solving?

This PR solves an issue where the search page would not load the second page of results when the query contained any URI encoded character such as a space `%20`. More details on the thread [here](https://vtex.slack.com/archives/CP6S9HP46/p1636663282242700) and the jira ticket [here](url). 

We're using try/catch for the decoding because some reasonable search terms such as "100% orange juice" make the `decodeURIComponent` function throw an error, so we want to avoid that.

#### How to test it?

Go to the [master workspace](https://tackoftheday.com/) on the account `tackoftheday` and search for something with a space, like "mountain horse".  Scroll down and try to load the next page. The results will show briefly but then they'll disappear.

Now go to this [workspace](https://icarovtex--tackoftheday.myvtex.com/) and do the same thing. It should work just fine.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/ignDUPybxGGNvEPINh/giphy.gif)
