### PR TITLE
SEO optimization tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Set new settings for:
+  - Add a #{Number} to the end of the title to avoid the title duplication issue
+  - Remove map parameter from canonical url. May cause issues when going to a page with facets selected. Test with caution after turning it on
+  - Remove store name at the end of Product and Category meta titles
 
 ## [2.120.1] - 2021-08-31
 ### Fixed
@@ -18,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.119.0] - 2021-06-09
 ### Added
-- `list` to `productView` GTM event (`productDetail`) 
+- `list` to `productView` GTM event (`productDetail`)
 
 ## [2.118.0] - 2021-06-08
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -213,13 +213,13 @@
             "title": "admin/store.advancedSettings.canonicalWithUrlParams.title",
             "description": "admin/store.advancedSettings.canonicalWithUrlParams.description",
             "type": "boolean",
-            "default": false
+            "default": true
           },
           "removeStoreNameTitle": {
             "title": "admin/store.advancedSettings.removeStoreNameTitle.title",
             "description": "admin/store.advancedSettings.removeStoreNameTitle.description",
             "type": "boolean",
-            "default": true
+            "default": false
           }
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -209,11 +209,11 @@
             "type": "boolean",
             "default": false
           },
-          "canonicalWithUrlParams": {
-            "title": "admin/store.advancedSettings.canonicalWithUrlParams.title",
-            "description": "admin/store.advancedSettings.canonicalWithUrlParams.description",
+          "canonicalWithoutUrlParams": {
+            "title": "admin/store.advancedSettings.canonicalWithoutUrlParams.title",
+            "description": "admin/store.advancedSettings.canonicalWithoutUrlParams.description",
             "type": "boolean",
-            "default": true
+            "default": false
           },
           "removeStoreNameTitle": {
             "title": "admin/store.advancedSettings.removeStoreNameTitle.title",

--- a/manifest.json
+++ b/manifest.json
@@ -205,6 +205,12 @@
             "description": "admin/store.advancedSettings.enableLazyFold.description",
             "type": "boolean",
             "default": false
+          },
+          "enablePageNumberTitle": {
+            "title": "admin/store.advancedSettings.enablePageNumberTitle.title",
+            "description": "admin/store.advancedSettings.enablePageNumberTitle.description",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -88,10 +88,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "admin/store.faviconLinks.description"
       },
@@ -217,6 +214,12 @@
             "description": "admin/store.advancedSettings.canonicalWithUrlParams.description",
             "type": "boolean",
             "default": false
+          },
+          "removeStoreNameTitle": {
+            "title": "admin/store.advancedSettings.removeStoreNameTitle.title",
+            "description": "admin/store.advancedSettings.removeStoreNameTitle.description",
+            "type": "boolean",
+            "default": true
           }
         }
       }
@@ -227,18 +230,14 @@
           {
             "properties": {
               "requiresAuthorization": {
-                "enum": [
-                  false
-                ]
+                "enum": [false]
               }
             }
           },
           {
             "properties": {
               "requiresAuthorization": {
-                "enum": [
-                  true
-                ]
+                "enum": [true]
               },
               "b2bEnabled": {
                 "title": "admin/store.b2benabled.title",
@@ -259,12 +258,7 @@
     "b2bEnabled": {
       "ui:disabled": "true"
     },
-    "ui:order": [
-      "storeName",
-      "requiresAuthorization",
-      "b2bEnabled",
-      "*"
-    ]
+    "ui:order": ["storeName", "requiresAuthorization", "b2bEnabled", "*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -211,6 +211,12 @@
             "description": "admin/store.advancedSettings.enablePageNumberTitle.description",
             "type": "boolean",
             "default": false
+          },
+          "canonicalWithUrlParams": {
+            "title": "admin/store.advancedSettings.canonicalWithUrlParams.title",
+            "description": "admin/store.advancedSettings.canonicalWithUrlParams.description",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -99,6 +99,11 @@ const getTitleTag = ({
   pageNumber = 0,
   removeStoreNameTitle,
 }: GetTitleTagParams) => {
+  /*
+  titleNumber and storeTitleFormatted depend on the value of enablePageNumberTitle and removeStoreNameTitle params,
+  by default, the value of enablePageNumberTitle and removeStoreNameTitle is false, only if the value of these
+  parameters is true, it will affect the value of titleNumber or storeTitleFormatted
+  */
   const titleNumber = pageNumber > 0 ? ` #${pageNumber}` : ''
   const storeTitleFormatted = removeStoreNameTitle ? '' : ` - ${storeTitle}`
 

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -120,7 +120,7 @@ const getTitleTag = ({
     )}${titleNumber}${storeTitleFormatted}`
   }
 
-  return `${storeTitle}`
+  return storeTitle
 }
 
 const getSearchIdentifier = (

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -392,7 +392,7 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
           getHelmetLink({
             canonicalLink,
             page: pageFromQuery,
-            map,
+            map: (settings.canonicalWithUrlParams ? map : ''),
             rel: 'canonical',
           }),
           getHelmetLink({

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -318,7 +318,7 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
     storeTitle: storeName || defaultStoreTitle,
     term: params.term,
     pageTitle,
-    pageNumber: enablePageNumberTitle ? +page : 0,
+    pageNumber: enablePageNumberTitle ? Number(page) : 0,
     removeStoreNameTitle,
   })
 

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -312,15 +312,15 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
   } = useRuntime() as RuntimeWithRoute
 
   const settings = getSettings(APP_LOCATOR) || ({} as StoreSettings)
+  // console.log('settings', settings)
   const loading = searchQuery ? searchQuery.loading : undefined
   const {
     titleTag: defaultStoreTitle,
     storeName,
     enablePageNumberTitle = false,
-    canonicalWithUrlParams = true,
+    canonicalWithoutUrlParams = false,
     removeStoreNameTitle = false,
   } = settings
-  // console.log('settings', settings)
 
   const title = getTitleTag({
     titleTag,
@@ -418,7 +418,7 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
           getHelmetLink({
             canonicalLink,
             page: pageFromQuery,
-            map: canonicalWithUrlParams ? map : '',
+            map: canonicalWithoutUrlParams ? '' : map,
             rel: 'canonical',
           }),
           getHelmetLink({

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -196,17 +196,10 @@ export function getHelmetLink({
     return null
   }
 
-  // console.log('\ncanonicalLink: ',canonicalLink,
-  //   '\npage: ',page,
-  //   '\nmap: ',map,
-  //   '\nrel: ',rel)
-
   let pageAfterTransformation = 0
 
   if (rel === 'canonical') {
     pageAfterTransformation = page
-
-    // console.log('canonical map', map )
   } else if (rel === 'next') {
     pageAfterTransformation = page + 1
   } else if (rel === 'prev') {
@@ -303,7 +296,6 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
     to,
     children,
   } = props
-  // console.log('map', map)
   const {
     account,
     getSettings,
@@ -312,7 +304,6 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
   } = useRuntime() as RuntimeWithRoute
 
   const settings = getSettings(APP_LOCATOR) || ({} as StoreSettings)
-  // console.log('settings', settings)
   const loading = searchQuery ? searchQuery.loading : undefined
   const {
     titleTag: defaultStoreTitle,

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -100,7 +100,7 @@ const getTitleTag = ({
   removeStoreNameTitle,
 }: GetTitleTagParams) => {
   const titleNumber = pageNumber > 0 ? ` #${pageNumber}` : ''
-  const storeTitleFormatted = removeStoreNameTitle ? ` - ${storeTitle}` : ''
+  const storeTitleFormatted = removeStoreNameTitle ? '' : ` - ${storeTitle}`
 
   if (titleTag) {
     return `${getDecodeURIComponent(
@@ -196,10 +196,17 @@ export function getHelmetLink({
     return null
   }
 
+  // console.log('\ncanonicalLink: ',canonicalLink,
+  //   '\npage: ',page,
+  //   '\nmap: ',map,
+  //   '\nrel: ',rel)
+
   let pageAfterTransformation = 0
 
   if (rel === 'canonical') {
     pageAfterTransformation = page
+
+    // console.log('canonical map', map )
   } else if (rel === 'next') {
     pageAfterTransformation = page + 1
   } else if (rel === 'prev') {
@@ -296,6 +303,7 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
     to,
     children,
   } = props
+  // console.log('map', map)
   const {
     account,
     getSettings,
@@ -309,14 +317,10 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
     titleTag: defaultStoreTitle,
     storeName,
     enablePageNumberTitle = false,
-    canonicalWithUrlParams = false,
+    canonicalWithUrlParams = true,
     removeStoreNameTitle = false,
   } = settings
-
-  // console.log('enablePageNumberTitle', enablePageNumberTitle)
-  // console.log('canonicalWithUrlParams', canonicalWithUrlParams)
-  // console.log('removeStoreNameTitle', removeStoreNameTitle)
-  // console.log('storeName: ', storeName, '\ndefaultStoreTitle: ', defaultStoreTitle)
+  // console.log('settings', settings)
 
   const title = getTitleTag({
     titleTag,

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -185,8 +185,9 @@ function useTitle(product: Product) {
   let title = titleTag ?? productName ?? ''
 
   const settings = getSettings(STORE_APP)
+  // console.log('settings', settings)
 
-  if (settings) {
+  if (settings?.removeStoreNameTitle === false) {
     const { storeName, titleTag: storeTitleTag } = settings
     const storeData = storeName || storeTitleTag
     if (storeData) {
@@ -258,9 +259,8 @@ const ProductTitleAndPixel: FC<Props> = ({
   loading,
   listName,
 }) => {
-  // console.log('ProductTitleAndPixel')
   const { metaTagDescription = undefined } = product || {}
-  const title = `${useTitle(product)}_DEMO`
+  const title = `${useTitle(product)}`
 
   const pixelCacheKey = path<string>(['linkText'], product)
   usePageView({

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -258,7 +258,7 @@ const ProductTitleAndPixel: FC<Props> = ({
   listName,
 }) => {
   const { metaTagDescription = undefined } = product || {}
-  const title = `${useTitle(product)}`
+  const title = useTitle(product)
 
   const pixelCacheKey = path<string>(['linkText'], product)
   usePageView({

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -179,13 +179,11 @@ function useProductEvents({
 }
 
 function useTitle(product: Product) {
-  // TODO: check title here
   const { getSettings } = useRuntime()
   const { titleTag = undefined, productName = undefined } = product || {}
   let title = titleTag ?? productName ?? ''
 
   const settings = getSettings(STORE_APP)
-  // console.log('settings', settings)
 
   if (settings?.removeStoreNameTitle === false) {
     const { storeName, titleTag: storeTitleTag } = settings

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -179,6 +179,7 @@ function useProductEvents({
 }
 
 function useTitle(product: Product) {
+  // TODO: check title here
   const { getSettings } = useRuntime()
   const { titleTag = undefined, productName = undefined } = product || {}
   let title = titleTag ?? productName ?? ''
@@ -257,8 +258,9 @@ const ProductTitleAndPixel: FC<Props> = ({
   loading,
   listName,
 }) => {
+  // console.log('ProductTitleAndPixel')
   const { metaTagDescription = undefined } = product || {}
-  const title = useTitle(product)
+  const title = `${useTitle(product)}_DEMO`
 
   const pixelCacheKey = path<string>(['linkText'], product)
   usePageView({

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -73,6 +73,7 @@ export const getCategoryMetadata = (searchQuery?: SearchQueryData) => {
 }
 
 export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
+  console.log('getSearchMetadata')
   if (
     !searchQuery ||
     !searchQuery.productSearch ||
@@ -92,6 +93,9 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
   }
 
   const department = getDepartment(searchQuery)
+
+  console.log('searchTerm', searchTerm)
+  console.log(' searchQuery.productSearch', searchQuery.productSearch)
 
   return {
     term: decodeURIComponent(searchTerm),

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -73,7 +73,6 @@ export const getCategoryMetadata = (searchQuery?: SearchQueryData) => {
 }
 
 export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
-  // console.log('getSearchMetadata')
   if (
     !searchQuery ||
     !searchQuery.productSearch ||
@@ -93,9 +92,6 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
   }
 
   const department = getDepartment(searchQuery)
-
-  // console.log('searchTerm', searchTerm)
-  // console.log(' searchQuery.productSearch', searchQuery.productSearch)
 
   return {
     term: decodeURIComponent(searchTerm),

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -73,7 +73,7 @@ export const getCategoryMetadata = (searchQuery?: SearchQueryData) => {
 }
 
 export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
-  console.log('getSearchMetadata')
+  // console.log('getSearchMetadata')
   if (
     !searchQuery ||
     !searchQuery.productSearch ||
@@ -94,8 +94,8 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
 
   const department = getDepartment(searchQuery)
 
-  console.log('searchTerm', searchTerm)
-  console.log(' searchQuery.productSearch', searchQuery.productSearch)
+  // console.log('searchTerm', searchTerm)
+  // console.log(' searchQuery.productSearch', searchQuery.productSearch)
 
   return {
     term: decodeURIComponent(searchTerm),

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -34,6 +34,7 @@ declare module 'vtex.render-runtime' {
     titleTag: string
     enablePageNumberTitle: boolean
     canonicalWithUrlParams: boolean
+    removeStoreNameTitle: boolean
   }
 
   interface KeyValue {

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -33,6 +33,7 @@ declare module 'vtex.render-runtime' {
     storeName: string
     titleTag: string
     enablePageNumberTitle: boolean
+    canonicalWithUrlParams: boolean
   }
 
   interface KeyValue {

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -32,6 +32,7 @@ declare module 'vtex.render-runtime' {
   interface StoreSettings {
     storeName: string
     titleTag: string
+    enablePageNumberTitle: boolean
   }
 
   interface KeyValue {

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -33,7 +33,7 @@ declare module 'vtex.render-runtime' {
     storeName: string
     titleTag: string
     enablePageNumberTitle: boolean
-    canonicalWithUrlParams: boolean
+    canonicalWithoutUrlParams: boolean
     removeStoreNameTitle: boolean
   }
 

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -80,6 +80,11 @@
           "title": "Enable Page Number Title",
           "type": "boolean",
           "description": "Indicate the search path of your store"
+        },
+        "canonicalWithUrlParams": {
+          "title": "Show canonical url with params Title",
+          "type": "boolean",
+          "description": "Show canonical url with params (description)"
         }
       }
     }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -75,6 +75,11 @@
               "description": "This setting disables the legacy orderForm provider. More at: https://vtex.io/docs/recipes/store-management/enabling-order-form-optimization."
             }
           }
+        },
+        "enablePageNumberTitle": {
+          "title": "Enable Page Number Title",
+          "type": "boolean",
+          "description": "Indicate the search path of your store"
         }
       }
     }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -76,17 +76,17 @@
         "enablePageNumberTitle": {
           "title": "Enable page number in meta title",
           "type": "boolean",
-          "description": "Show page number in the title"
+          "description": "Add a #{Number} to the end of the title to avoid the title duplication issue"
         },
         "canonicalWithoutUrlParams": {
-          "title": "Show canonical url with params",
+          "title": "Canonical url without url params",
           "type": "boolean",
-          "description": "Show canonical url with params (description)"
+          "description": "Remove map parameter from canonical url. May cause issues when going to a page with facets selected. Test with caution after turning it on"
         },
         "removeStoreNameTitle": {
-          "title": "Enable Store Name Title",
+          "title": "Remove store name from title",
           "type": "boolean",
-          "description": "Show store name in the title"
+          "description": "Remove store name at the end of Product and Category meta titles"
         }
       }
     }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -52,10 +52,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "rel",
-              "href"
-            ]
+            "required": ["rel", "href"]
           },
           "description": "Configure your store's favicons"
         },
@@ -79,12 +76,17 @@
         "enablePageNumberTitle": {
           "title": "Enable Page Number Title",
           "type": "boolean",
-          "description": "Indicate the search path of your store"
+          "description": "Show page number in the title"
         },
         "canonicalWithUrlParams": {
-          "title": "Show canonical url with params Title",
+          "title": "Show canonical url with params",
           "type": "boolean",
           "description": "Show canonical url with params (description)"
+        },
+        "removeStoreNameTitle": {
+          "title": "Enable Store Name Title",
+          "type": "boolean",
+          "description": "Show store name in the title"
         }
       }
     }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -74,11 +74,11 @@
           }
         },
         "enablePageNumberTitle": {
-          "title": "Enable Page Number Title",
+          "title": "Enable page number in meta title",
           "type": "boolean",
           "description": "Show page number in the title"
         },
-        "canonicalWithUrlParams": {
+        "canonicalWithoutUrlParams": {
           "title": "Show canonical url with params",
           "type": "boolean",
           "description": "Show canonical url with params (description)"

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -76,17 +76,17 @@
         "enablePageNumberTitle": {
           "title": "Enable page number in meta title",
           "type": "boolean",
-          "description": "Add a #{Number} to the end of the title to avoid the title duplication issue"
+          "description": "Add a #{Number} to the end of the title to avoid the title duplication issue."
         },
         "canonicalWithoutUrlParams": {
           "title": "Canonical url without url params",
           "type": "boolean",
-          "description": "Remove map parameter from canonical url. May cause issues when going to a page with facets selected. Test with caution after turning it on"
+          "description": "Remove map parameter from canonical url. May cause issues when going to a page with facets selected. Test with caution after turning it on."
         },
         "removeStoreNameTitle": {
           "title": "Remove store name from title",
           "type": "boolean",
-          "description": "Remove store name at the end of Product and Category meta titles"
+          "description": "Remove store name at the end of Product and Category meta titles."
         }
       }
     }


### PR DESCRIPTION
#### What problem is this solving?

- Set new settings in /admin/cms/store for SEO optimization :
  - Add a #{Number} to the end of the title to avoid the title duplication issue
  - Remove map parameter from canonical url. May cause issues when going to a page with facets selected. Test with caution after turning it on
  - Remove store name at the end of Product and Category meta titles

#### How to test it?

[Worksapce](https://seotask2--powerplanet.myvtex.com/fundas-y-protectores-smartphone/smart?__bindingAddress=www.we-demostore.com/es&_q=smart&fuzzy=0&initialMap=ft&initialQuery=smart&map=category-2,ft&operator=and)

  - Add a #{Number} to the end of the title to avoid the title duplication issue
    - *Search some term, for example "smart", after, use button "Mostrar más"*
  - Remove map parameter from canonical url. May cause issues when going to a page with facets selected. Test with caution after turning it on.
     - *Apply some filters over search result, after, press F12 and go to "Elements", find rel="canonical" and check his href attribute*
  - Remove store name at the end of Product and Category meta titles
    - *Go to some Product or Category page,  press F12 and go to "Elements" and  find <title> element*

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/84771232/145962786-ea9d4b72-dab0-4138-9e9c-82d2eb6f86c8.png)

#### Related to / Depends on
[admin-pages](https://github.com/vtex-apps/admin-pages/pull/414)

#### Notes
Some settings may take time to be reflected in the store

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/TLulTJKuyLgMU/giphy.gif)
