### PR TITLE
Add Open Graph meta tags to custom Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add Open Graph `<meta>` to `store.custom` pages
+
 ### Fixed
 - Category and department metadata when `categoriesTree` doesn't exist.
 

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-filename-extension */
-import React, { Fragment, useEffect } from 'react'
+import React, { Fragment, useEffect, useMemo } from 'react'
 import {
   canUseDOM,
   ExtensionPoint,
@@ -27,6 +27,7 @@ const APP_LOCATOR = 'vtex.store'
 const CONTENT_TYPE = 'text/html; charset=utf-8'
 const META_ROBOTS = 'index, follow'
 const MOBILE_SCALING = 'width=device-width, initial-scale=1'
+const CUSTOM_PAGE = 'store.custom'
 
 const isSiteEditorIframe = () => {
   try {
@@ -36,6 +37,15 @@ const isSiteEditorIframe = () => {
   } catch {
     return false
   }
+}
+
+const getCustomPagesOpenGraph = ({ title, description, url }) => {
+  return [
+    { property: 'og:type', content: 'website' },
+    { property: 'og:title', content: title },
+    { property: 'og:url', content: url },
+    { property: 'og:description', content: description },
+  ]
 }
 
 const useFavicons = faviconLinks => {
@@ -59,7 +69,7 @@ const StoreWrapper = ({ children, CustomContext }) => {
     amp,
     culture: { country, locale, currency },
     route,
-    route: { metaTags, title: pageTitle },
+    route: { metaTags, title: pageTitle, rootName },
     getSettings,
     rootPath = '',
     prefetchDefaultPages,
@@ -108,6 +118,8 @@ const StoreWrapper = ({ children, CustomContext }) => {
 
   const CustomContextElement = CustomContext || Fragment
 
+  const isCustomPage = useMemo(() => rootName.includes(CUSTOM_PAGE), [rootName])
+
   const content = (
     <OrderQueueProvider>
       <OrderFormProviderCheckout>
@@ -124,6 +136,13 @@ const StoreWrapper = ({ children, CustomContext }) => {
       <Helmet
         title={title}
         meta={[
+          ...(isCustomPage
+            ? getCustomPagesOpenGraph({
+                title,
+                description,
+                url: canonicalLink,
+              })
+            : []),
           // viewport meta tag is already handled in render-server for AMP pages
           !amp && { name: 'viewport', content: MOBILE_SCALING },
           { name: 'description', content: description },


### PR DESCRIPTION
#### What problem is this solving?

Almost all regular pages have open graph meta tags but `store.custom` Pages doesn't have them.

This PR adds this meta tags to the pages :
 
 `<meta property=og:type /> `
  `<meta property=og:title /> `
  `<meta property=og:url />` 
 ` <meta property=og:description />`

#### How to test it?
In this [Workspace](https://custompagesopengraph--oficinareserva.myvtex.com/) you will enter the `/vert` page and see the meta tags of the image below

#### Screenshots or example usage:
 
![Screenshot from 2021-12-15 01-10-30](https://user-images.githubusercontent.com/58344276/146181754-defef0a0-b219-4be2-aba0-62e2e48699a9.png)


#### Related to / Depends on

Related to [#594](https://github.com/vtex-apps/store-discussion/issues/594) 