### PR TITLE
fix: encoded term creating an URI error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+- Adjusted the logic on the searchMetadata file to avoid URI malformed error on searches with % at the end and keeping the older logic working.
+
 ## [2.120.3] - 2021-12-20
 ### Fixed
 - Search's `query` is now URL decoded whenever possible. This avoids unnecessary updates on the page when the query contain spaces coded as `%20`, for example, and makes "Show More" functionality work correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## Fixed
+### Fixed
 - Adjusted the logic on the searchMetadata file to avoid URI malformed error on searches with % at the end and keep the older logic working.
 
 ## [2.120.3] - 2021-12-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## Fixed
-- Adjusted the logic on the searchMetadata file to avoid URI malformed error on searches with % at the end and keeping the older logic working.
+- Adjusted the logic on the searchMetadata file to avoid URI malformed error on searches with % at the end and keep the older logic working.
 
 ## [2.120.3] - 2021-12-20
 ### Fixed

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -122,10 +122,21 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
     return
   }
 
+  let decodedTerm = ''
+  
+  // This try catch works to prevent decoding terms when having % on the end 
+  // and the decode isn't necessary
+
+  try {
+    decodedTerm = decodeURIComponent(searchTerm)
+  } catch (e) {
+    decodedTerm = decodeURIComponent(encodeURIComponent(searchTerm))
+  }
+
   const department = getDepartment(searchQuery)
 
   return {
-    term: decodeURIComponent(searchTerm),
+    term: decodedTerm,
     category: department ? { id: department.id, name: department.name } : null,
     results: searchQuery.productSearch.recordsFiltered,
     operator: searchQuery.productSearch.operator,

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -123,8 +123,7 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
   }
 
   let decodedTerm = ''
-  // This try catch works to prevent decoding terms when having % on the end 
-  // and the decode isn't necessary
+  // This try/catch works to prevent decoding search terms that end in "%".
   try {
     decodedTerm = decodeURIComponent(searchTerm)
   } catch (e) {

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -123,10 +123,8 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
   }
 
   let decodedTerm = ''
-  
   // This try catch works to prevent decoding terms when having % on the end 
   // and the decode isn't necessary
-
   try {
     decodedTerm = decodeURIComponent(searchTerm)
   } catch (e) {


### PR DESCRIPTION
#### What problem is this solving?

We have some searches that have the '%' on the end and this is crashing due to the decode that is made as commented on the code itself the ideia is to maintain the logic of decoding (avoiding crashing searches that need to be decoded), but also avoiding the error of URI malformed decoding an encodedURI.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace]
https://rfonseca--oceane.myvtex.com/batom%20100%?_q=batom%20100%&map=ft
https://rfonseca--mundopet.myvtex.com/ra%C3%A7%C3%A3o%20100%?_q=ra%C3%A7%C3%A3o%20100%&map=ft
https://rfonseca--gigadigital.myvtex.com/alcool%2070%?_q=alcool%2070%&map=ft

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/49077396/148804029-776ec8b1-865c-4c93-a016-6d886ffbadc1.png)

Comparing to the master workspace

![image](https://user-images.githubusercontent.com/49077396/148808009-c950f903-d8c4-48f4-843d-513306fd583f.png)

#### How does this PR make you feel? [:link:] https://media.giphy.com/media/JNyX5Vdr9mtjgMqp2G/giphy.gif
