### PR TITLE
change decodeURIComponent to decodeURI in the getCorrectQueryValue fu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Bug where queries with `/` are not being encoded.
+
 ## [2.123.0] - 2022-03-08
 ### Added
 - Arabic, Norwegian and Norwegian variant translations.

--- a/react/SearchContext.jsx
+++ b/react/SearchContext.jsx
@@ -87,7 +87,7 @@ const SearchContext = ({
     }
 
     try {
-      return decodeURIComponent(queryValue)
+      return decodeURI(queryValue)
     } catch {
       return queryValue
     }


### PR DESCRIPTION
#### What problem is this solving?

If you search for a term that contains a not encoded slash like `llave 3/4`, the query will be split and only the`llave 3` will be sent.

#### How to test it?

[Before](https://master--graingermx.myvtex.com/llave%203%2f4?_q=llave%203/4&map=ft)
[After](https://hiago--graingermx.myvtex.com/llave%203%2f4?_q=llave%203/4&map=ft)

#### Screenshots or example usage:

Before
![image](https://user-images.githubusercontent.com/40380674/159984892-e513c5a6-2791-4511-808d-40e8b65360c3.png)

After
![image](https://user-images.githubusercontent.com/40380674/159984927-22d32f42-b8ce-40a6-a449-61f9338eba31.png)


