### PR TITLE
Add `bindingBounded` flag to `settingsSchema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for different settings by binding.
 
 ## [2.124.0] - 2022-04-26 [YANKED]
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -39,6 +39,7 @@
   "settingsSchema": {
     "title": "admin/store.title",
     "type": "object",
+    "bindingBounded": true,
     "properties": {
       "storeName": {
         "title": "admin/store.storeName.title",


### PR DESCRIPTION
#### What problem is this solving?

This enables the `bindingBounded` flag again, enabling stores to use different settings for different bindings in the same account.

#### How to test it?

Go to this [Workspace](https://victormiranda--storecomponents.myvtex.com/admin/cms/store) and check that a new `Enable configuration by binging` toggle is present in the settings form. When active, this enables users to set up configurations per binding.

#### Screenshots or example usage:

![Captura de Tela 2022-05-16 às 15 35 58](https://user-images.githubusercontent.com/27777263/168659695-c18ee914-1a53-47fd-ab4e-a8219fe4730b.png)

![Captura de Tela 2022-05-16 às 15 36 07](https://user-images.githubusercontent.com/27777263/168659714-9e75baf3-179a-4b2d-9d84-c172f1395d66.png)

#### Related to / Depends on

This pretty much just brings back the changes from #538, but after the deployment of https://github.com/vtex/builder-hub/pull/1148.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/YPIrsRqqO7oB2/giphy.gif)
