### PR TITLE
fix: change titleTag and pageTitle for settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Switch titleTag and pageTitle attribute inside the title meta to read the defined settings first. 
 
 ## [2.125.0] - 2022-05-17
 ### Added

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -108,7 +108,7 @@ const StoreWrapper = ({ children, CustomContext }) => {
   } = settings
 
   const description = (metaTags && metaTags.description) || metaTagDescription
-  const title = pageTitle || titleTag
+  const title = titleTag || pageTitle
 
   const [queryMatch] = route.path.match(/\?.*/) || ['?']
 


### PR DESCRIPTION
#### What problem is this solving?

The title saved on the Admin interface represents the titleTag property. when a store has both pageTitle and titleTag, the title meta does not load as expected.  
An hkignore version has been released to fix the problem. 
vtex.store@2.125.1-hkignore.0
#### How to test it?

1.- Go to the store admin and verify the settings declared: yamamay.myvtex.com/admin/cms/store
2.- go to this workspace where the fix is not implemented. https://cesar--yamamay.myvtex.com/?__bindingAddress=www.yamamay.com/it_it and check the value of the titleTag
3.- Go to master and check the titleTag that corresponds to the settings. 


#### Screenshots or example usage:

1.- Store Admin Config 
![Screenshot 2022-07-04 at 12 36 31](https://user-images.githubusercontent.com/58808189/177137986-c4dc0475-5aa4-435d-b08b-94ec7f434fdb.png)
2.- Workspace without the fix:
![Screenshot 2022-07-04 at 12 32 53](https://user-images.githubusercontent.com/58808189/177138049-17472683-5ada-4f2c-b1a4-8a5b244c8e5d.png)
3.- Master with the Fix and hkignore
![Screenshot 2022-07-04 at 12 35 50](https://user-images.githubusercontent.com/58808189/177138096-b62b84a9-6f43-4fb3-9ff0-c30afdf1106e.png)


