### PR TITLE
feat: use custom currency symbol from trade policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Setting a new flag to use the custom currency symbol `enableCustomCurrencySymbol`
+- Setting a new flag to use the custom currency symbol in store settings: `enableCustomCurrencySymbol`
 
 
 ## [2.125.0] - 2022-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Setting a new flag to use the custom currency symbol `enableCustomCurrencySymbol`
+
 
 ## [2.125.0] - 2022-05-17
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -89,10 +89,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "admin/store.faviconLinks.description"
       },
@@ -224,6 +221,12 @@
             "description": "admin/store.advancedSettings.removeStoreNameTitle.description",
             "type": "boolean",
             "default": false
+          },
+          "enableCustomCurrencySymbol": {
+            "title": "admin/store.advancedSettings.enableCustomCurrencySymbol.title",
+            "description": "admin/store.advancedSettings.enableCustomCurrencySymbol.description",
+            "type": "boolean",
+            "default": false
           }
         }
       }
@@ -234,18 +237,14 @@
           {
             "properties": {
               "requiresAuthorization": {
-                "enum": [
-                  false
-                ]
+                "enum": [false]
               }
             }
           },
           {
             "properties": {
               "requiresAuthorization": {
-                "enum": [
-                  true
-                ]
+                "enum": [true]
               },
               "b2bEnabled": {
                 "title": "admin/store.b2benabled.title",
@@ -266,12 +265,7 @@
     "b2bEnabled": {
       "ui:disabled": "true"
     },
-    "ui:order": [
-      "storeName",
-      "requiresAuthorization",
-      "b2bEnabled",
-      "*"
-    ]
+    "ui:order": ["storeName", "requiresAuthorization", "b2bEnabled", "*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
#### What problem is this solving?

Currently, the user is not able to get the value from the custom currency symbol in Trade Policy, this feature allows the user to retrieve it and now set it on the UI

#### How to test it?

Account: koestore
Product id: 1

First of all, you need to define your custom currency symbol at the trade policy screen:

`admin/Site/StoreForm.aspx?Id=1`

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/13649073/178053085-24296d79-78c8-41af-921b-da61f1a9b65e.png">

Set the flag `enableCustomCurrencySymbol` as true in your store search settings at: admin/cms/store

<img width="452" alt="image" src="https://user-images.githubusercontent.com/13649073/178060504-4d199698-5c47-4231-9404-67643a011981.png">


Check the product page or any other page that has the currency symbol:

[PDP with the fix:](https://iespinoza2--koestore.myvtex.com/camisa-botafogo/p) 

<img width="1265" alt="image" src="https://user-images.githubusercontent.com/13649073/178053782-512c4e98-2380-429f-8a4b-33d668601d5f.png">

[PDP without the fix getting from intl:](https://master--koestore.myvtex.com/camisa-botafogo/p) 

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/13649073/178054084-44a613f2-dd6c-4da5-a2af-918c2f9cb054.png">


#### Related to / Depends on

This other PR with the feature: https://github.com/vtex-apps/format-currency/pull/29

Zendesk 590112

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/3o7btNa0RUYa5E7iiQ/giphy.gif)