### PR TITLE
Fix search metadata for category events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Search metadata for category events.
+
 ## [2.125.0] - 2022-05-17
 ### Added
 - Support for different settings by binding.

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -269,7 +269,7 @@ interface CategoryMetadata {
 }
 
 interface SearchMetadata {
-  term: string
+  term?: string
   category: CategoryMetadata | null
   results: number
 }

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -118,22 +118,18 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
 
   const searchTerm = queryMap.ft
 
-  if (!searchTerm) {
-    return
-  }
-
   let decodedTerm = ''
   // This try/catch works to prevent decoding search terms that end in "%".
   try {
-    decodedTerm = decodeURIComponent(searchTerm)
+    decodedTerm = decodeURIComponent(searchTerm || '')
   } catch (e) {
-    decodedTerm = decodeURIComponent(encodeURIComponent(searchTerm))
+    decodedTerm = decodeURIComponent(encodeURIComponent(searchTerm || ''))
   }
 
   const department = getDepartment(searchQuery)
 
   return {
-    term: decodedTerm,
+    term: decodedTerm || undefined,
     category: department ? { id: department.id, name: department.name } : null,
     results: searchQuery.productSearch.recordsFiltered,
     operator: searchQuery.productSearch.operator,


### PR DESCRIPTION
#### What problem is this solving?

Search events were being sent without the number of results for category pages. This was affecting search reports, because these pages were being reported as empty searches.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--exitocol.myvtex.com/tecnologia/televisores)

#### Screenshots or example usage:
Before (match: 0)
<img width="253" alt="image" src="https://user-images.githubusercontent.com/20840671/178583938-aa1291f2-5f54-4b30-b3ed-96aa552f5e29.png">

After (match: 797 - total products for this search)
<img width="250" alt="image" src="https://user-images.githubusercontent.com/20840671/178583846-98b987a3-5bb1-45a8-91f3-1cd53ed0e0b4.png">


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
