### PR TITLE
Add Indonesian and fix old translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Indonesian translation.
+
+### Fixed
+- Spanish and Thai translations.
+
 ## [2.128.0] - 2022-12-12
 
 ### Fixed

--- a/messages/id-ID.json
+++ b/messages/id-ID.json
@@ -1,0 +1,8 @@
+{
+  "admin/editor.product-search.title": "Konteks pencarian produk",
+  "admin/editor.product-search.maxItemsPerPage": "Jumlah maksimum item per halaman",
+  "admin/editor.product-search.hideUnavailableItems": "Sembunyikan item yang tidak tersedia",
+  "store/store.network-status.offline": "Tidak ada koneksi internet.",
+  "admin/actions.enable-binding": "Aktifkan konfigurasi dengan pengikatan",
+  "admin/actions.binding-configurations": "Konfigurasi pengikatan"
+}


### PR DESCRIPTION
Add Indonesian and fix Spanish and Thai translations. Tracked by task [LOC-9012](https://vtex-dev.atlassian.net/browse/LOC-9012).