### PR TITLE
Allow 4-level category map in SearchWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow `SearchWrapper` to support 4-level category maps
+
 ## [2.127.0] - 2022-08-03
 ### Added
 - Setting a new flag to use the custom currency symbol in store settings: `enableCustomCurrencySymbol`

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -155,7 +155,7 @@ function shouldNotIncludeMap(map?: string) {
 
   const mapTree = map.split(',')
 
-  if (mapTree.length > 3) {
+  if (mapTree.length > 4) {
     return false
   }
 

--- a/react/__tests__/SearchWrapper.test.ts
+++ b/react/__tests__/SearchWrapper.test.ts
@@ -183,9 +183,9 @@ describe('getHelmetLink function', () => {
     expect(canonicalLinkResult).toHaveProperty('href', expectedResult)
   })
 
-  it('should return the map on the canonical url when map has more than 3 categories', () => {
+  it('should return the map on the canonical url when map has more than 4 categories', () => {
     const canonicalLink = 'https://storetheme.vtex.com/apparel---accessories/'
-    const map = 'c,c,c,c'
+    const map = 'c,c,c,c,c'
 
     const canonicalLinkResult = getHelmetLink({
       canonicalLink,


### PR DESCRIPTION
#### What problem is this solving?

Client `muralsyourway` uses a four-level category structure. Currently, the code that generates the canonical link for category pages is hardcoded to append a `map` query string if the category tree has more than 3 levels, resulting in a canonical like `https://muralsyourway.myvtex.com/c/animal-murals/bird-murals/owl-murals?map=c%2Cc%2Cc%2Cc`. 

This PR raises this hardcoded limit to 4. The `map` query string will still be appended if all four parts of the map are not `c`. 

#### How to test it?

Linked here: https://arthur--muralsyourway.myvtex.com/c/animal-murals/bird-murals/owl-murals

Inspect the page and compare the canonical URL to the one from master here: https://muralsyourway.myvtex.com/c/animal-murals/bird-murals/owl-murals 