### PR TITLE
[USAAPPTEAM-727] Fix search canonical links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Include `_q` query parameter in search page canonical URLs
+- Provide `meta.canonical` prop to `SearchOpenGraph` component, to ensure `og:url` and canonical are consistent 
+
 ## [2.127.1] - 2022-10-06
 
 ### Fixed


### PR DESCRIPTION
#### What problem is this solving?

A US client noted two problems with their canonical URLs and open graph metatags:
- the page https://www.budgetgolf.com/black%20shoes?_q=black%20shoes&map=ft has a canonical URL that does not match the actual URL (the `_q` query string is missing from the canonical)
- the same page has an `og:url` metatag that does not match either the canonical URL or the actual URL (the `og:url` lacks any query strings)

This PR in conjunction with https://github.com/vtex-apps/open-graph/pull/33 fixes both issues.

To fix the first issue, the `_q` query param is now added to canonical URLs if it's present in the page URL.
To fix the second issue, the canonical URL generated by the `SearchWrapper` component is now passed to the `SearchOpenGraph` component as a prop, ensuring that the two metatags match. 

#### How to test it?

Linked here: https://arthur--budgetgolf.myvtex.com/black%20shoes?_q=black%20shoes&map=ft

Note: this PR does not introduce any breaking changes. It can be merged before or after the open-graph PR is merged.