### PR TITLE
New translations in Catalan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Catalan translation.
+
 ## [2.129.0] - 2022-12-23
 
 ### Added

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -1,0 +1,10 @@
+{
+    "admin/editor.product-search.title": "Context de cerca de productes",
+    "admin/editor.product-search.maxItemsPerPage": "Nombre màxim d'elements per pàgina",
+    "admin/editor.product-search.hideUnavailableItems": "Amagar elements no disponibles",
+    "store/store.network-status.offline": "Sense connexió a internet.",
+    "admin/actions.enable-binding": "Activar la configuració per vinculació",
+    "admin/actions.binding-configurations": "Configuració de vinculació",
+    "admin/actions.binding-id": "ID d'enllaç",
+    "admin/actions.binding-description": "Introduïu l'ID d'enllaç"
+  }

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -1,10 +1,10 @@
 {
-    "admin/editor.product-search.title": "Context de cerca de productes",
-    "admin/editor.product-search.maxItemsPerPage": "Nombre màxim d'elements per pàgina",
-    "admin/editor.product-search.hideUnavailableItems": "Amagar elements no disponibles",
-    "store/store.network-status.offline": "Sense connexió a internet.",
-    "admin/actions.enable-binding": "Activar la configuració per vinculació",
-    "admin/actions.binding-configurations": "Configuració de vinculació",
-    "admin/actions.binding-id": "ID d'enllaç",
-    "admin/actions.binding-description": "Introduïu l'ID d'enllaç"
-  }
+  "admin/editor.product-search.title": "Context de cerca de productes",
+  "admin/editor.product-search.maxItemsPerPage": "Nombre màxim d'articles per pàgina",
+  "admin/editor.product-search.hideUnavailableItems": "Amaga els articles no disponibles",
+  "store/store.network-status.offline": "Sense connexió a internet.",
+  "admin/actions.enable-binding": "Activar la configuració per vinculació",
+  "admin/actions.binding-configurations": "Configuració de vinculació",
+  "admin/actions.binding-id": "ID d'enllaç",
+  "admin/actions.binding-description": "Introduïu l'ID d'enllaç"
+}


### PR DESCRIPTION
#### What problem is this solving?

This feature adds a file in the "messages" directory with all the translations of this app in Català. 

#### How to test it?

For test, enter in the workspace  and disconnect the internet. Thereupon you can see a toast message with one of the translations ("Sense connexió a internet.").

[Workspace](https://xavidevelop--ametllerorigen.myvtex.com/?__bindingAddress=www.ametllerorigen.com/ca&sc=14)

#### Screenshots or example usage:

![Captura desde 2023-02-20 11-07-11](https://user-images.githubusercontent.com/77384330/220077412-b2a7b14f-95d4-4806-99be-01e136369fc4.png)

#### Describe alternatives you've considered, if any.

Another way to translate the content of a store is overwriting the messages via GraphQL IDE (https://developers.vtex.com/docs/guides/vtex-io-documentation-overwriting-the-messages-app).
Consider that if you have made changes via GraphQL these will prevail over the files.


