### PR TITLE
Add German translations to make it available across Admin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- German translation.
+
 ## [2.129.0] - 2022-12-23
 
 ### Added

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,0 +1,10 @@
+{
+  "admin/editor.product-search.title": "Kontext der Produktsuche",
+  "admin/editor.product-search.maxItemsPerPage": "Maximale Anzahl von Artikeln pro Seite",
+  "admin/editor.product-search.hideUnavailableItems": "Nicht verfügbare Artikel ausblenden",
+  "store/store.network-status.offline": "Keine Internetverbindung.",
+  "admin/actions.enable-binding": "Konfiguration durch Bindung aktivieren",
+  "admin/actions.binding-configurations": "Bindung-Konfigurationen",
+  "admin/actions.binding-id": "Bindungs-ID",
+  "admin/actions.binding-description": "Geben Sie die Bindungs-ID ein"
+}


### PR DESCRIPTION
#### What problem is this solving?

This is part of a series of PRs in several apps to make German available across the Admin. Tracked in task [LOC-9843](https://vtex-dev.atlassian.net/browse/LOC-9843).

#### How to test it?

A test store with DE in the language switcher is [available here](https://localizationqa--obidev.myvtex.com/admin/).