### PR TITLE
fix: `ProfileChallenge` redirect URL not preserving query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
-- `location.search` in URL redirect on `ProfileChallenge`
+### Fixed
+- `ProfileChallenge` URL redirect not preserving the query params (`location.search`)
 
 ## [2.131.0] - 2023-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- ADD `location.search` in url redirect on `ProfileChallenge`
 
 ## [2.131.0] - 2023-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `location.search` in URL redirect on `ProfileChallenge`
 
-
 ## [2.131.0] - 2023-03-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- ADD `location.search` in url redirect on `ProfileChallenge`
+
+### Added
+- `location.search` in URL redirect on `ProfileChallenge`
+
 
 ## [2.131.0] - 2023-03-28
 

--- a/react/ProfileChallenge.tsx
+++ b/react/ProfileChallenge.tsx
@@ -14,13 +14,14 @@ const loginPath = '/login'
 const getLocation = () =>
   canUseDOM
     ? {
-        url: window.location.pathname + window.location.hash,
+        url: window.location.pathname + window.location.search + window.location.hash,
         pathName: window.location.pathname,
       }
     : {
         url: (global as any).__pathname__,
         pathName: (global as any).__pathname__,
       }
+
 
 const useSessionResponse = () => {
   const [session, setSession] = useState<SessionResponse>()

--- a/react/ProfileChallenge.tsx
+++ b/react/ProfileChallenge.tsx
@@ -14,14 +14,16 @@ const loginPath = '/login'
 const getLocation = () =>
   canUseDOM
     ? {
-        url: window.location.pathname + window.location.search + window.location.hash,
+        url:
+          window.location.pathname +
+          window.location.search +
+          window.location.hash,
         pathName: window.location.pathname,
       }
     : {
         url: (global as any).__pathname__,
         pathName: (global as any).__pathname__,
       }
-
 
 const useSessionResponse = () => {
   const [session, setSession] = useState<SessionResponse>()


### PR DESCRIPTION
#### What problem is this solving?

When mounting the redirect URL from login, the method `getLocation` ignored URL parameters and lost them.

This problem is common on pages with URI like `/checkout/orderplaced?og=09876543210978`.