### PR TITLE
Feature: sponsored products toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Adds the advanced setting `fetchSponsoredProductsOnSearch`.
+
 ## [2.132.0] - 2023-08-24
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -230,6 +230,12 @@
             "description": "admin/store.advancedSettings.enableCustomCurrencySymbol.description",
             "type": "boolean",
             "default": false
+          },
+          "fetchSponsoredProductsOnSearch": {
+            "title": "admin/store.advancedSettings.fetchSponsoredProductsOnSearch.title",
+            "description": "admin/store.advancedSettings.fetchSponsoredProductsOnSearch.description",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.133.0-beta.0",
+  "version": "2.132.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.132.0",
+  "version": "2.133.0-beta.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -70,6 +70,12 @@
               "type": "boolean",
               "default": false,
               "description": "This setting disables the legacy orderForm provider. More at: https://vtex.io/docs/recipes/store-management/enabling-order-form-optimization."
+            },
+            "fetchSponsoredProductsOnSearch": {
+              "title": "[BETA] Fetch sponsored products in search results",
+              "type": "boolean",
+              "default": false,
+              "description": "If this store's account has configured VTEX Ads, this option enables the fetching of sponsored products within search results."
             }
           }
         },


### PR DESCRIPTION
#### What problem is this solving?

Adds the advanced setting `fetchSponsoredProductsOnSearch`, which is going to be used by the `search-result` app to know whether or not to fetch sponsored products.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://oneclickads--sjdigital.myvtex.com/admin/cms/store)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/store/assets/15937541/ea38139c-f91f-4824-a4ab-debd4ba35fc7)

#### Related to / Depends on

Depends on:
[ ] https://github.com/vtex-apps/admin-pages/pull/456
