### PR TITLE
feat(meta): validação para metatag robots

### DIFF
--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -32,6 +32,7 @@ import { PixelEvent } from './typings/event'
 import { useCanonicalLink } from './hooks/useCanonicalLink'
 
 const APP_LOCATOR = 'vtex.store'
+const META_ROBOTS = 'noindex,follow'
 
 interface SearchRouteParams {
   term?: string
@@ -321,11 +322,12 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
   const {
     titleTag: defaultStoreTitle,
     storeName,
+    metaTagRobots,
     enablePageNumberTitle = false,
     canonicalWithoutUrlParams = false,
     removeStoreNameTitle = false,
   } = settings
-
+ 
   const title = getTitleTag({
     titleTag,
     storeTitle: storeName || defaultStoreTitle,
@@ -334,6 +336,8 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
     pageNumber: enablePageNumberTitle ? Number(page) : 0,
     removeStoreNameTitle,
   })
+
+  const robots = !metaTagRobots ? (metaTags || {})?.robots : metaTagRobots
 
   const canonicalLink = useCanonicalLink()
 
@@ -421,7 +425,7 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
         meta={[
           params.term && {
             name: 'robots',
-            content: 'noindex,follow',
+            content: robots ?? META_ROBOTS,
           },
           metaTagDescription && {
             name: 'description',

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -21,6 +21,7 @@ declare module 'vtex.render-runtime' {
 
   interface MetaTagsParams {
     description: string
+    robots: string
     keywords: string[]
   }
 
@@ -31,6 +32,7 @@ declare module 'vtex.render-runtime' {
 
   interface StoreSettings {
     storeName: string
+    metaTagRobots: string
     titleTag: string
     enablePageNumberTitle: boolean
     canonicalWithoutUrlParams: boolean


### PR DESCRIPTION
#### What problem is this solving?

Páginas que possuem termo, estão com valor "noindex,follow" fixo no código na tag <meta robots="">.
Foi adicionado uma validação para ter a possibilidade de mudar esse valor e ser dinâmico, possibilitando que essas páginas possam ter também o valor "index,follow".

Ex de página que possui termo e sempre possui valor "noindex,follow" como default: https://robotsteste--samsclub.myvtex.com/1354?map=productClusterIds

#### How to test it?

[Workspace](https://robotsteste--samsclub.myvtex.com/1354?map=productClusterIds)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/store/assets/94130589/08b97008-49fc-468d-92bc-c01e229f06c2)
![image](https://github.com/vtex-apps/store/assets/94130589/2e538068-4e20-4afc-b1c6-047e479ac1f3)


