### PR TITLE
SAX-53 Change sponsoredProductsBehavior default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Default value for `sponsoredProductsBehavior` as `sync` instead of `skip`.
+
 ## [2.134.0] - 2023-12-13
 
 ### Added

--- a/react/SearchContext.jsx
+++ b/react/SearchContext.jsx
@@ -26,7 +26,7 @@ const SearchContext = ({
   installmentCriteria,
   excludedPaymentSystems,
   includedPaymentSystems,
-  sponsoredProductsBehavior = 'skip',
+  sponsoredProductsBehavior = 'sync',
   query: {
     order: orderBy = orderByField || SORT_OPTIONS[0].value,
     page: pageQuery,
@@ -235,7 +235,7 @@ SearchContext.schema = {
     sponsoredProductsBehavior: {
       title: 'Sponsored products behavior',
       type: 'string',
-      default: 'skip',
+      default: 'sync',
     },
   },
 }


### PR DESCRIPTION
#### What problem is this solving?
https://vtex-dev.atlassian.net/browse/SAX-53

Depends on https://github.com/vtex-apps/store-resources/pull/181

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[workspace](https://thalyta--lebiscuit.myvtex.com/fritadeira?_q=fritadeira&map=ft)
* IMPORTANT: Changing the value to `sync` won't call sponsored products for all accounts, since they still have to enable the setting `fetchSponsoredProductsOnSearch`

#### Screenshots or example usage:

https://github.com/vtex-apps/store-resources/assets/20840671/4808562c-ac8b-4d0e-b7f7-c28483f25892


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
