### PR TITLE
fix: discount not being sent in view_item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `PriceWithoutDiscount` in productViewEvent
+
 ## [2.135.0] - 2024-03-07
 
 ### Changed

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -124,8 +124,8 @@ function getSkuProperties(item: SKU): SKUEvent {
         Price: seller.commertialOffer.Price,
         ListPrice: seller.commertialOffer.ListPrice,
         AvailableQuantity: seller.commertialOffer.AvailableQuantity,
-        PriceWithoutDiscount: 
-          seller.commertialOffer?.PriceWithoutDiscount || 
+        PriceWithoutDiscount:
+          seller.commertialOffer?.PriceWithoutDiscount ||
           seller.commertialOffer.Price,
       },
     })),

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -124,7 +124,8 @@ function getSkuProperties(item: SKU): SKUEvent {
         Price: seller.commertialOffer.Price,
         ListPrice: seller.commertialOffer.ListPrice,
         AvailableQuantity: seller.commertialOffer.AvailableQuantity,
-        PriceWithoutDiscount: seller.commertialOffer?.PriceWithoutDiscount || seller.commertialOffer.Price,
+        PriceWithoutDiscount: seller.commertialOffer?.PriceWithoutDiscount || 
+          seller.commertialOffer.Price,
       },
     })),
   }

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -124,7 +124,7 @@ function getSkuProperties(item: SKU): SKUEvent {
         Price: seller.commertialOffer.Price,
         ListPrice: seller.commertialOffer.ListPrice,
         AvailableQuantity: seller.commertialOffer.AvailableQuantity,
-        PriceWithoutDiscount: seller.commertialOffer?.PriceWithoutDiscount || 0
+        PriceWithoutDiscount: seller.commertialOffer?.PriceWithoutDiscount || 0,
       },
     })),
   }

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -77,6 +77,7 @@ interface CommertialOffer {
   ListPrice: number
   Price: number
   AvailableQuantity: number
+  PriceWithoutDiscount: number
 }
 
 type MaybeProduct = Product | null
@@ -123,6 +124,7 @@ function getSkuProperties(item: SKU): SKUEvent {
         Price: seller.commertialOffer.Price,
         ListPrice: seller.commertialOffer.ListPrice,
         AvailableQuantity: seller.commertialOffer.AvailableQuantity,
+        PriceWithoutDiscount: seller.commertialOffer?.PriceWithoutDiscount || 0
       },
     })),
   }

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -124,7 +124,8 @@ function getSkuProperties(item: SKU): SKUEvent {
         Price: seller.commertialOffer.Price,
         ListPrice: seller.commertialOffer.ListPrice,
         AvailableQuantity: seller.commertialOffer.AvailableQuantity,
-        PriceWithoutDiscount: seller.commertialOffer?.PriceWithoutDiscount || 
+        PriceWithoutDiscount: 
+          seller.commertialOffer?.PriceWithoutDiscount || 
           seller.commertialOffer.Price,
       },
     })),

--- a/react/components/ProductTitleAndPixel.tsx
+++ b/react/components/ProductTitleAndPixel.tsx
@@ -124,7 +124,7 @@ function getSkuProperties(item: SKU): SKUEvent {
         Price: seller.commertialOffer.Price,
         ListPrice: seller.commertialOffer.ListPrice,
         AvailableQuantity: seller.commertialOffer.AvailableQuantity,
-        PriceWithoutDiscount: seller.commertialOffer?.PriceWithoutDiscount || 0,
+        PriceWithoutDiscount: seller.commertialOffer?.PriceWithoutDiscount || seller.commertialOffer.Price,
       },
     })),
   }


### PR DESCRIPTION
#### What problem is this solving?

Discount not being sent in view_item event due to missing PriceWithoutDiscount in ProductViewEvent

#### How to test it?

Check dataLayer in your console

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Before](https://master--casablanca.myvtex.com/almohadon-estampado-digital-playstation-gris/p?skuId=2857)

![image](https://github.com/vtex-apps/store/assets/13649073/0afd5bab-07e5-4b57-ba4e-6b484237018e)


[After](https://ccanelas--casablanca.myvtex.com/almohadon-estampado-digital-playstation-gris/p?skuId=2857)

![image](https://github.com/vtex-apps/store/assets/13649073/0abfb11a-56cd-4843-8d29-ce03a84fb84b)


#### Related to / Depends on

Zendesk: #1022268

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExamJ0MXhjMGI0d2k4NjZjMmczejhtOXQxaHZ3bjUxN2F1c2FmbXZ0NSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Fh7gIgpEzvpNOyiLr3/giphy.gif)
