### PR TITLE
add: possibility to add more than one custom header per account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Custom Headers to be added in the UI
 
+### Added
+- Removed search term path from the UI
+
 ## [2.136.0] - 2024-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Custom Headers to be added in the UI
 
-### Added
-- Removed search term path from the UI
+### Removed
+- Search term path from the UI
 
 ## [2.136.0] - 2024-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Custom Headers to be added in the UI
+
 ## [2.136.0] - 2024-05-22
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -233,27 +233,31 @@
             "default": false
           },
           "customHeader": {
-            "title": "Custom Header",
+            "title": "admin/store.advancedSettings.customHeader.title",
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
                 "__editorItemTitle": {
-                  "title": "Header ID",
-                  "description": "Id to identify your header. eg: My new Custom Header",
-                  "type": "string"
+                  "type": "string",
+                  "title": "admin/store.advancedSettings.customHeader.__editorItemTitle.title",
+                  "description": "admin/store.advancedSettings.customHeader.__editorItemTitle.description"
                 },
                 "key": {
                   "type": "string",
-                  "description": "Key for you header following HTTP patterns. e.g: Strict-Transport-Security",
-                  "title": "Key"
+                  "title": "admin/store.advancedSettings.customHeader.key.title",
+                  "description": "admin/store.advancedSettings.customHeader.key.description"
                 },
                 "value": {
                   "type": "string",
-                  "description": "Value for you key following HTTP patterns. e.g: max-age=<expire-time>",
-                  "title": "Value"
+                  "title": "admin/store.advancedSettings.customHeader.value.title",
+                  "description": "admin/store.advancedSettings.customHeader.value.description"
                 }
-              }
+              },
+              "required": [
+                "key",
+                "value"
+              ]              
             }
           }
         }

--- a/manifest.json
+++ b/manifest.json
@@ -95,12 +95,7 @@
           ]
         },
         "description": "admin/store.faviconLinks.description"
-      },
-      "searchTermPath": {
-        "title": "admin/store.searchTermPath.title",
-        "type": "string",
-        "description": "admin/store.searchTermPath.description"
-      },
+      },      
       "advancedSettings": {
         "title": "admin/store.advancedSettings.title",
         "type": "object",
@@ -236,6 +231,30 @@
             "description": "admin/store.advancedSettings.fetchSponsoredProductsOnSearch.description",
             "type": "boolean",
             "default": false
+          },
+          "customHeader": {
+            "title": "Custom Header",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "__editorItemTitle": {
+                  "title": "Header ID",
+                  "description": "Id to identify your header. eg: My new Custom Header",
+                  "type": "string"
+                },
+                "key": {
+                  "type": "string",
+                  "description": "Key for you header following HTTP patterns. e.g: Strict-Transport-Security",
+                  "title": "Key"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "Value for you key following HTTP patterns. e.g: max-age=<expire-time>",
+                  "title": "Value"
+                }
+              }
+            }
           }
         }
       }

--- a/messages/ar-SA.json
+++ b/messages/ar-SA.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Enable configuration by binding",
   "admin/actions.binding-configurations": "Binding configurations",
   "admin/actions.binding-id": "Binding ID",
-  "admin/actions.binding-description": "Enter the binding ID"
+  "admin/actions.binding-description": "Enter the binding ID",
+  "admin/store.advancedSettings.customHeader.title": "ترويسات مخصصة",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "معرّف الترويسة",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "أدخل المعرف لتعريف الترويسة الخاصة بك. مثال: ترويسة مخصصة جديدة",
+  "admin/store.advancedSettings.customHeader.key.title": "مفتاح الترويسة",
+  "admin/store.advancedSettings.customHeader.key.description": "أدخل مفتاح الترويسة الخاص بك، باتباع أنماط HTTP. مثال: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "قيمة الترويسة",
+  "admin/store.advancedSettings.customHeader.value.description": "أدخل قيمة المفتاح الخاص بك، باتباع أنماط HTTP. مثال: max-age=<expire-time>"
 }

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Enable configuration by binding",
   "admin/actions.binding-configurations": "Binding configurations",
   "admin/actions.binding-id": "Binding ID",
-  "admin/actions.binding-description": "Enter the binding ID"
+  "admin/actions.binding-description": "Enter the binding ID",
+  "admin/store.advancedSettings.customHeader.title": "ترويسات مخصصة",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "معرّف الترويسة",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "أدخل المعرف لتعريف الترويسة الخاصة بك. مثال: ترويسة مخصصة جديدة",
+  "admin/store.advancedSettings.customHeader.key.title": "مفتاح الترويسة",
+  "admin/store.advancedSettings.customHeader.key.description": "أدخل مفتاح الترويسة الخاص بك، باتباع أنماط HTTP. مثال: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "قيمة الترويسة",
+  "admin/store.advancedSettings.customHeader.value.description": "أدخل قيمة المفتاح الخاص بك، باتباع أنماط HTTP. مثال: max-age=<expire-time>"
 }

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Активиране на конфигурацията чрез обвързване",
   "admin/actions.binding-configurations": "Обвързващи конфигурации",
   "admin/actions.binding-id": "ID за обвързване",
-  "admin/actions.binding-description": "Въведете ID за обвързване"
+  "admin/actions.binding-description": "Въведете ID за обвързване",
+  "admin/store.advancedSettings.customHeader.title": "Персонализирани заглавки",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID на заглавка",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Въведете ID, за да идентифицирате заглавката си. Пример: Моята нова персонализирана заглавка",
+  "admin/store.advancedSettings.customHeader.key.title": "Ключ на заглавка",
+  "admin/store.advancedSettings.customHeader.key.description": "Въведете ключа за вашата заглавка, като следвате принципите на HTTP. Пример: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Стойност на заглавка",
+  "admin/store.advancedSettings.customHeader.value.description": "Въведете стойността на вашия ключ, като следвате принципите на HTTP. Пример: max-age=<expire-time>"
 }

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Activar la configuració per vinculació",
   "admin/actions.binding-configurations": "Configuració de vinculació",
   "admin/actions.binding-id": "ID d'enllaç",
-  "admin/actions.binding-description": "Introduïu l'ID d'enllaç"
+  "admin/actions.binding-description": "Introduïu l'ID d'enllaç",
+  "admin/store.advancedSettings.customHeader.title": "Capçaleres personalitzades",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID de la capçalera",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Introduïu l'ID per identificar la capçalera. Exemple: La meva nova capçalera personalitzada",
+  "admin/store.advancedSettings.customHeader.key.title": "Clau de la capçalera",
+  "admin/store.advancedSettings.customHeader.key.description": "Introduïu la clau de la capçalera seguint patrons HTTP. Exemple: Seguretat-Estricta-en el Transport",
+  "admin/store.advancedSettings.customHeader.value.title": "Valor de la capçalera",
+  "admin/store.advancedSettings.customHeader.value.description": "Introduïu el valor de la capçalera seguint patrons HTTP. Exemple: edat-màxima=<expire-time>"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "admin/actions.enable-binding",
   "admin/actions.binding-configurations": "admin/actions.binding-configurations",
   "admin/actions.binding-id": "admin/actions.binding-id",
-  "admin/actions.binding-description": "admin/actions.binding-description"
+  "admin/actions.binding-description": "admin/actions.binding-description",
+  "admin/store.advancedSettings.customHeader.title": "admin/store.advancedSettings.customHeader.title",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "admin/store.advancedSettings.customHeader.__editorItemTitle.title",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "admin/store.advancedSettings.customHeader.__editorItemTitle.description",
+  "admin/store.advancedSettings.customHeader.key.title": "admin/store.advancedSettings.customHeader.__editorItemTitle.title",
+  "admin/store.advancedSettings.customHeader.key.description": "admin/store.advancedSettings.customHeader.__editorItemTitle.description",
+  "admin/store.advancedSettings.customHeader.value.title": "admin/store.advancedSettings.customHeader.__editorItemTitle.title",
+  "admin/store.advancedSettings.customHeader.value.description": "admin/store.advancedSettings.customHeader.__editorItemTitle.description"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Konfiguration durch Bindung aktivieren",
   "admin/actions.binding-configurations": "Bindung-Konfigurationen",
   "admin/actions.binding-id": "Bindungs-ID",
-  "admin/actions.binding-description": "Geben Sie die Bindungs-ID ein"
+  "admin/actions.binding-description": "Geben Sie die Bindungs-ID ein",
+  "admin/store.advancedSettings.customHeader.title": "Benutzerdefinierte Kopfzeilen",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Kopfzeilen-ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Geben Sie die ID ein, um Ihre Kopfzeile zu identifizieren. Beispiel: Meine neue benutzerdefinierte Kopfzeile",
+  "admin/store.advancedSettings.customHeader.key.title": "Kopfzeilen-Schlüssel",
+  "admin/store.advancedSettings.customHeader.key.description": "Geben Sie den Schlüssel für Ihre Kopfzeile ein und folgen Sie dabei den HTTP-Mustern. Beispiel: Strenge-Transport-Sicherheit",
+  "admin/store.advancedSettings.customHeader.value.title": "Kopfzeilen-Wert",
+  "admin/store.advancedSettings.customHeader.value.description": "Geben Sie den Wert für Ihren Schlüssel ein und folgen Sie dabei den HTTP-Mustern. Beispiel: Maximal-Alter=<expire-time>"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -11,7 +11,7 @@
   "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Header ID",
   "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Id to identify your header. e.g: My new Custom Header",
   "admin/store.advancedSettings.customHeader.key.title": "Header Key",
-  "admin/store.advancedSettings.customHeader.key.description": "Key to you header following HTTP patterns. e.g: Strict-Transport-Security",  
+  "admin/store.advancedSettings.customHeader.key.description": "Key for your header following HTTP patterns. e.g: Strict-Transport-Security",
   "admin/store.advancedSettings.customHeader.value.title": "Header Value",
-  "admin/store.advancedSettings.customHeader.value.description": "Value to you key following HTTP patterns. e.g: max-age=<expire-time>"
+  "admin/store.advancedSettings.customHeader.value.description": "Value for your key following HTTP patterns. e.g: max-age=<expire-time>"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Enable configuration by binding",
   "admin/actions.binding-configurations": "Binding configurations",
   "admin/actions.binding-id": "Binding ID",
-  "admin/actions.binding-description": "Enter the binding ID"
+  "admin/actions.binding-description": "Enter the binding ID",
+  "admin/store.advancedSettings.customHeader.title": "Custom Headers",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Header ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Id to identify your header. eg: My new Custom Header",
+  "admin/store.advancedSettings.customHeader.key.title": "Header Key",
+  "admin/store.advancedSettings.customHeader.key.description": "Key to you header following HTTP patterns. e.g: Strict-Transport-Security",  
+  "admin/store.advancedSettings.customHeader.value.title": "Header Value",
+  "admin/store.advancedSettings.customHeader.value.description": "Value to you key following HTTP patterns. e.g: max-age=<expire-time>"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,7 +9,7 @@
   "admin/actions.binding-description": "Enter the binding ID",
   "admin/store.advancedSettings.customHeader.title": "Custom Headers",
   "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Header ID",
-  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Id to identify your header. eg: My new Custom Header",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Id to identify your header. e.g: My new Custom Header",
   "admin/store.advancedSettings.customHeader.key.title": "Header Key",
   "admin/store.advancedSettings.customHeader.key.description": "Key to you header following HTTP patterns. e.g: Strict-Transport-Security",  
   "admin/store.advancedSettings.customHeader.value.title": "Header Value",

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,9 +9,9 @@
   "admin/actions.binding-description": "Enter the binding ID",
   "admin/store.advancedSettings.customHeader.title": "Custom Headers",
   "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Header ID",
-  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Id to identify your header. e.g: My new Custom Header",
-  "admin/store.advancedSettings.customHeader.key.title": "Header Key",
-  "admin/store.advancedSettings.customHeader.key.description": "Key for your header following HTTP patterns. e.g: Strict-Transport-Security",
-  "admin/store.advancedSettings.customHeader.value.title": "Header Value",
-  "admin/store.advancedSettings.customHeader.value.description": "Value for your key following HTTP patterns. e.g: max-age=<expire-time>"
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Enter the ID to identify your header. Example: My new custom header",
+  "admin/store.advancedSettings.customHeader.key.title": "Header key",
+  "admin/store.advancedSettings.customHeader.key.description": "Enter the key for your header, following HTTP patterns. Example: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Header value",
+  "admin/store.advancedSettings.customHeader.value.description": "Enter the value for your key, following HTTP patterns. Example: max-age=<expire-time>"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Activar la configuración por vinculación",
   "admin/actions.binding-configurations": "Configuración de vinculación",
   "admin/actions.binding-id": "ID de vínculo",
-  "admin/actions.binding-description": "Introduce el ID de vínculo"
+  "admin/actions.binding-description": "Introduce el ID de vínculo",
+  "admin/store.advancedSettings.customHeader.title": "Encabezados personalizados",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID del encabezado",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Ingresa el ID para identificar tu encabezado. Ejemplo: Nuevo encabezado personalizado",
+  "admin/store.advancedSettings.customHeader.key.title": "Clave del encabezado",
+  "admin/store.advancedSettings.customHeader.key.description": "Ingresa la clave de tu encabezado, en formato HTTP. Ejemplo: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Valor del encabezado",
+  "admin/store.advancedSettings.customHeader.value.description": "Ingresa el valor de tu clave, en formato HTTP. Ejemplo: max-age=<expire-time>"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Permettre la configuration par liaison",
   "admin/actions.binding-configurations": "Configurations de liaison",
   "admin/actions.binding-id": "ID de liaison",
-  "admin/actions.binding-description": "Saisir l'ID de la liaison"
+  "admin/actions.binding-description": "Saisir l'ID de la liaison",
+  "admin/store.advancedSettings.customHeader.title": "En-têtes personnalisés",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID de l'en-tête",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Saisissez l'ID pour identifier votre en-tête. Exemple : Mon nouvel en-tête personnalisé",
+  "admin/store.advancedSettings.customHeader.key.title": "Clé de l'en-tête",
+  "admin/store.advancedSettings.customHeader.key.description": "Saisissez la clé de votre en-tête, en suivant les modèles HTTP. Exemple : Strict-Transport-Sécurité",
+  "admin/store.advancedSettings.customHeader.value.title": "Valeur de l'en-tête",
+  "admin/store.advancedSettings.customHeader.value.description": "Saisissez la valeur de votre clé, en suivant les modèles HTTP. Exemple : max-age=<expire-time>"
 }

--- a/messages/id-ID.json
+++ b/messages/id-ID.json
@@ -4,5 +4,12 @@
   "admin/editor.product-search.hideUnavailableItems": "Sembunyikan item yang tidak tersedia",
   "store/store.network-status.offline": "Tidak ada koneksi internet.",
   "admin/actions.enable-binding": "Aktifkan konfigurasi dengan pengikatan",
-  "admin/actions.binding-configurations": "Konfigurasi pengikatan"
+  "admin/actions.binding-configurations": "Konfigurasi pengikatan",
+  "admin/store.advancedSettings.customHeader.title": "Header Kustom",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID header",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Masukkan ID untuk mengidentifikasi header Anda. Contoh: Header kustom baru saya",
+  "admin/store.advancedSettings.customHeader.key.title": "Kunci header",
+  "admin/store.advancedSettings.customHeader.key.description": "Masukkan kunci untuk header mengikuti pola HTTP. Contoh: Keamanan-Transportasi-Ketat",
+  "admin/store.advancedSettings.customHeader.value.title": "Isi header",
+  "admin/store.advancedSettings.customHeader.value.description": "Masukkan isi untuk kunci mengikuti pola HTTP. Contoh: usia maksimal=<expire-time>"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "바인딩하여 구성 활성화",
   "admin/actions.binding-configurations": "바인딩 구성",
   "admin/actions.binding-id": "바인딩 ID",
-  "admin/actions.binding-description": "바인딩 ID 입력"
+  "admin/actions.binding-description": "바인딩 ID 입력",
+  "admin/store.advancedSettings.customHeader.title": "사용자 지정 헤더",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "헤더 ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "헤더를 식별할 ID를 입력합니다. 예시: 내 새 사용자 지정 헤더",
+  "admin/store.advancedSettings.customHeader.key.title": "헤더 키",
+  "admin/store.advancedSettings.customHeader.key.description": "HTTP 패턴에 따라 헤더의 키를 입력합니다. 예시: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "헤더 값",
+  "admin/store.advancedSettings.customHeader.value.description": "HTTP 패턴에 따라 키의 값을 입력합니다. 예시: max-age=<expire-time>"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Configuratie inschakelen door binding",
   "admin/actions.binding-configurations": "Bindende configuraties",
   "admin/actions.binding-id": "Bindende ID",
-  "admin/actions.binding-description": "Voer de bindende ID in"
+  "admin/actions.binding-description": "Voer de bindende ID in",
+  "admin/store.advancedSettings.customHeader.title": "Aangepaste headers",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Header-id",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Voer de id in om uw header te identificeren. Voorbeeld: Mijn nieuwe aangepaste header",
+  "admin/store.advancedSettings.customHeader.key.title": "Headersleutel",
+  "admin/store.advancedSettings.customHeader.key.description": "Voer de sleutel in voor uw header, volgens HTTP-patronen. Voorbeeld: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Headerwaarde",
+  "admin/store.advancedSettings.customHeader.value.description": "Voer de waarde in voor uw sleutel, volgens HTTP-patronen. Voorbeeld: max-age=<expire-time>"
 }

--- a/messages/nn.json
+++ b/messages/nn.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Aktiver konfigurasjon ved binding",
   "admin/actions.binding-configurations": "Konfigurasjoner ved binding",
   "admin/actions.binding-id": "Bindings-ID",
-  "admin/actions.binding-description": "Angi bindings-ID"
+  "admin/actions.binding-description": "Angi bindings-ID",
+  "admin/store.advancedSettings.customHeader.title": "Tilpass Topptekst",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Topptekst ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Skriv inn id for å identifisere topptekstet. Eksempel: Min nye egendefinerte topptekst",
+  "admin/store.advancedSettings.customHeader.key.title": "Topptekst nøkkel",
+  "admin/store.advancedSettings.customHeader.key.description": "Skriv inn nøkkelen for topptekstet etter HTTP-mønster. Eksempel: Strekk - Sikkerhet",
+  "admin/store.advancedSettings.customHeader.value.title": "Topptekst verdi",
+  "admin/store.advancedSettings.customHeader.value.description": "Angi verdien for nøkkelen din, etter HTTP mønster. Eksempel: max-age=<expire-time>"
 }

--- a/messages/no-NO.json
+++ b/messages/no-NO.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Aktiver konfigurasjon ved binding",
   "admin/actions.binding-configurations": "Konfigurasjoner ved binding",
   "admin/actions.binding-id": "Bindings-ID",
-  "admin/actions.binding-description": "Angi bindings-ID"
+  "admin/actions.binding-description": "Angi bindings-ID",
+  "admin/store.advancedSettings.customHeader.title": "Tilpass Topptekst",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Topptekst ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Skriv inn id for å identifisere topptekstet. Eksempel: Min nye egendefinerte topptekst",
+  "admin/store.advancedSettings.customHeader.key.title": "Topptekst nøkkel",
+  "admin/store.advancedSettings.customHeader.key.description": "Skriv inn nøkkelen for topptekstet etter HTTP-mønster. Eksempel: Strekk - Sikkerhet",
+  "admin/store.advancedSettings.customHeader.value.title": "Topptekst verdi",
+  "admin/store.advancedSettings.customHeader.value.description": "Angi verdien for nøkkelen din, etter HTTP mønster. Eksempel: max-age=<expire-time>"
 }

--- a/messages/no.json
+++ b/messages/no.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Aktiver konfigurasjon ved binding",
   "admin/actions.binding-configurations": "Konfigurasjoner ved binding",
   "admin/actions.binding-id": "Bindings-ID",
-  "admin/actions.binding-description": "Angi bindings-ID"
+  "admin/actions.binding-description": "Angi bindings-ID",
+  "admin/store.advancedSettings.customHeader.title": "Tilpass Topptekst",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Topptekst ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Skriv inn id for å identifisere topptekstet. Eksempel: Min nye egendefinerte topptekst",
+  "admin/store.advancedSettings.customHeader.key.title": "Topptekst nøkkel",
+  "admin/store.advancedSettings.customHeader.key.description": "Skriv inn nøkkelen for topptekstet etter HTTP-mønster. Eksempel: Strekk - Sikkerhet",
+  "admin/store.advancedSettings.customHeader.value.title": "Topptekst verdi",
+  "admin/store.advancedSettings.customHeader.value.description": "Angi verdien for nøkkelen din, etter HTTP mønster. Eksempel: max-age=<expire-time>"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -7,11 +7,11 @@
   "admin/actions.binding-configurations": "Configurações de vínculos",
   "admin/actions.binding-id": "ID de vínculo",
   "admin/actions.binding-description": "Insira o ID de vínculo",
-  "admin/store.advancedSettings.customHeader.title": "Custom Headers",
-  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Header ID",
-  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Id para identificar seu Header. ex: Meu novo Header Customizado",
-  "admin/store.advancedSettings.customHeader.key.title": " Chave do Header",
-  "admin/store.advancedSettings.customHeader.key.description": "Chave do seu header seguindo o protocolo HTTP. ex: Strict-Transport-Security",  
-  "admin/store.advancedSettings.customHeader.value.title": "Valor do Header",
-  "admin/store.advancedSettings.customHeader.value.description": "Value da chave do seu header seguindo o protocolo HTTP. ex: max-age=<expire-time>"
+  "admin/store.advancedSettings.customHeader.title": "Cabeçalhos personalizados",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID do cabeçalho",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Insira o ID para identificar o seu cabeçalho. Exemplo: Meu novo cabeçalho personalizado",
+  "admin/store.advancedSettings.customHeader.key.title": "Chave do cabeçalho",
+  "admin/store.advancedSettings.customHeader.key.description": "Insira a chave do seu cabeçalho, seguindo os padrões HTTP. Exemplo: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Valor do cabeçalho",
+  "admin/store.advancedSettings.customHeader.value.description": "Insira o valor de sua chave, seguindo os padrões HTTP. Exemplo: max-age=<expire-time>"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Habilitar configuração por vínculo",
   "admin/actions.binding-configurations": "Configurações de vínculos",
   "admin/actions.binding-id": "ID de vínculo",
-  "admin/actions.binding-description": "Insira o ID de vínculo"
+  "admin/actions.binding-description": "Insira o ID de vínculo",
+  "admin/store.advancedSettings.customHeader.title": "Custom Headers",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Header ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Id para identificar seu Header. ex: Meu novo Header Customizado",
+  "admin/store.advancedSettings.customHeader.key.title": " Chave do Header",
+  "admin/store.advancedSettings.customHeader.key.description": "Chave do seu header seguindo o protocolo HTTP. ex: Strict-Transport-Security",  
+  "admin/store.advancedSettings.customHeader.value.title": "Valor do Header",
+  "admin/store.advancedSettings.customHeader.value.description": "Value da chave do seu header seguindo o protocolo HTTP. ex: max-age=<expire-time>"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "Activează configurația prin legătură",
   "admin/actions.binding-configurations": "Configurații ale legăturii",
   "admin/actions.binding-id": "ID de legătură",
-  "admin/actions.binding-description": "Introdu ID-ul de legătură"
+  "admin/actions.binding-description": "Introdu ID-ul de legătură",
+  "admin/store.advancedSettings.customHeader.title": "Antet Custom",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID Antet",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Id pentru a vă identifica antetul. ex: noul meu antet personalizat",
+  "admin/store.advancedSettings.customHeader.key.title": "Cheie Antet",
+  "admin/store.advancedSettings.customHeader.key.description": "Cheia pentru antetul dvs. urmând modele HTTP. ex: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Valoare Antet",
+  "admin/store.advancedSettings.customHeader.value.description": "Valoare pentru cheia antetului urmând modele HTTP. ex: max-age=<expire-time>"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -7,11 +7,11 @@
   "admin/actions.binding-configurations": "Configurații ale legăturii",
   "admin/actions.binding-id": "ID de legătură",
   "admin/actions.binding-description": "Introdu ID-ul de legătură",
-  "admin/store.advancedSettings.customHeader.title": "Antet Custom",
-  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID Antet",
-  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Id pentru a vă identifica antetul. ex: noul meu antet personalizat",
-  "admin/store.advancedSettings.customHeader.key.title": "Cheie Antet",
-  "admin/store.advancedSettings.customHeader.key.description": "Cheia pentru antetul dvs. urmând modele HTTP. ex: Strict-Transport-Security",
-  "admin/store.advancedSettings.customHeader.value.title": "Valoare Antet",
-  "admin/store.advancedSettings.customHeader.value.description": "Valoare pentru cheia antetului urmând modele HTTP. ex: max-age=<expire-time>"
+  "admin/store.advancedSettings.customHeader.title": "Anteturi personalizate",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID antet",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Introdu ID-ul pentru a identifica antetul. Exemplu: Noul meu antet personalizat",
+  "admin/store.advancedSettings.customHeader.key.title": "Cheie antet",
+  "admin/store.advancedSettings.customHeader.key.description": "Introdu cheia pentru antetul tău, urmând modelele HTTP. Exemplu: Strict-Transport-Securitate",
+  "admin/store.advancedSettings.customHeader.value.title": "Valoare antet",
+  "admin/store.advancedSettings.customHeader.value.description": "Introdu valoarea pentru cheia ta, urmând modelele HTTP. Exemplu: max-age=<expire-time>"
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -6,5 +6,12 @@
   "admin/actions.enable-binding": "เปิดใช้ค่ากำหนดด้วยการผูกค่า",
   "admin/actions.binding-configurations": "การกำหนดค่าการผูกข้อมูล",
   "admin/actions.binding-id": "รหัสการผูกข้อมูล",
-  "admin/actions.binding-description": "ใส่รหัสการผูกข้อมูล"
+  "admin/actions.binding-description": "ใส่รหัสการผูกข้อมูล",
+  "admin/store.advancedSettings.customHeader.title": "Custom Headers",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Header ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Enter the ID to identify your header. Example: My new custom header",
+  "admin/store.advancedSettings.customHeader.key.title": "Header key",
+  "admin/store.advancedSettings.customHeader.key.description": "Enter the key for your header, following HTTP patterns. Example: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Header value",
+  "admin/store.advancedSettings.customHeader.value.description": "Enter the value for your key, following HTTP patterns. Example: max-age=<expire-time>"
 }


### PR DESCRIPTION
#### What problem is this solving?

Nowadays it's only possible to add custom headers through the settings API. The purpose of this PR is to give the possibility for the merchant or any other team to customize it through the store settings UI.

Also removed the searchTermPath since this isn't being used anymore for a while

#### How to test it?

Go to advanced tab at

[Workspace](https://customheader--storecomponents.myvtex.com/admin/cms/store)

#### Screenshots or example usage:

![image](https://github.com/user-attachments/assets/ee212f8b-3cf4-4670-b297-422cf7bd6a00)

There are some improvements that we might make in the design system when opening the modal

#### Related to / Depends on

[Render Server 803](https://github.com/vtex/render-server/pull/803)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXNwN3F0YWVmZnI2MnVvYmtrM3RnZ21zdGl0Mm1ueDFjNWRkZTJ2YyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/N7uh5YzIgdcxjZ8CgH/giphy.gif)
