### PR TITLE
fix: remove product list from search wrapper

### DIFF
--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -16,7 +16,6 @@ import {
   StoreSettings,
 } from 'vtex.render-runtime'
 import { SearchOpenGraph } from 'vtex.open-graph'
-import { ProductList as ProductListStructuredData } from 'vtex.structured-data'
 import queryString from 'query-string'
 
 import { capitalize } from './modules/capitalize'
@@ -447,7 +446,6 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
         ].filter(Boolean)}
       />
 
-      <ProductListStructuredData products={searchQuery.products} />
       <SearchOpenGraph meta={openGraphParams} />
       <LoadingContextProvider value={loadingValue}>
         <CustomContextElement>


### PR DESCRIPTION

### What problem is this solving?

This commit has the intention to fix the dupplication of a structured data Product List that usually occurs on PLP

### How to test it?

[Workspace with error](https://www.sportline.com.ar/mujer/calzados/zapatillas)

**Steps to reproduce:**

* Open the link above
* Open DevTools
* Go to Elements tab
* Search (cmd+f) for the following string: `{"@context":"https://schema.org","@type":"ItemList","itemListElement"`

**Expected Behavior:**

* You should find two occurrences of this string
* The content of the Structured JSON that starts with the searched string must be the same (duplicates)

[Workspace with fix](https://productlistdup--sportline.myvtex.com/mujer/calzados/zapatillas)

**Steps to reproduce:**

* Open the link above
* Open DevTools
* Go to Elements tab
* Search (cmd+f) for the following string: `{"@context":"https://schema.org","@type":"ItemList","itemListElement"`

**Expected Behavior:**

* You should find only one occurrence of this string. 
  * The first occurrence in the HTML, from the `SearchWrapper` component, has been removed

### Screenshots or example usage:

**Before Fix:**

First Occurrence:
![image](https://github.com/user-attachments/assets/f5c6383e-83ed-4940-85f2-d200f2f4282f)

Second Occurrence:
![image](https://github.com/user-attachments/assets/0500c454-1cf0-4c40-85d2-8d0f129e28a2)

**After Fix:**

![image](https://github.com/user-attachments/assets/3cdc8070-6cec-4766-8a99-06589370deae)


####Describe alternatives you've considered, if any.

We tried approaching the problem by adding a conditional in [vtex.product-summary](https://github.com/vtex-apps/product-summary/blob/b3ceeb9896d97d5f90cd4a04f200799761c574f2/react/ProductSummaryList.tsx#L255) that uses `useRuntime().page` to check if the user is in a search page  (evaluates to `search.page#<context>`).   
It was considered a safer approach that would cover possible scenarios where a search page can exist without a PLP.

Unfortunately, It did not work because when `useRuntime().page` is evaluated, it returns`store.home` (in sportline). Also, when checking for `__RUNTIME__.page` in the browser console, the page correctly evaluates to a `search.page#<context>`. I did not understand why this happened, so I am submitting this PR instead.

### Related to / Depends on

N/A

### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExd29lNnNrcDRvczVpc2hhNjB1YXJkNmZhZ2ZyN3U3dGp1NmN2YTFhZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/8L0yOaWLNmHnm9T4yy/giphy.webp)
