### PR TITLE
fix: typo in context message keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Context message keys for customHeader
+
 ## [2.137.1] - 2024-10-08
 
 ### Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -10,8 +10,8 @@
   "admin/store.advancedSettings.customHeader.title": "admin/store.advancedSettings.customHeader.title",
   "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "admin/store.advancedSettings.customHeader.__editorItemTitle.title",
   "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "admin/store.advancedSettings.customHeader.__editorItemTitle.description",
-  "admin/store.advancedSettings.customHeader.key.title": "admin/store.advancedSettings.customHeader.__editorItemTitle.title",
-  "admin/store.advancedSettings.customHeader.key.description": "admin/store.advancedSettings.customHeader.__editorItemTitle.description",
-  "admin/store.advancedSettings.customHeader.value.title": "admin/store.advancedSettings.customHeader.__editorItemTitle.title",
-  "admin/store.advancedSettings.customHeader.value.description": "admin/store.advancedSettings.customHeader.__editorItemTitle.description"
+  "admin/store.advancedSettings.customHeader.key.title": "admin/store.advancedSettings.customHeader.key.title",
+  "admin/store.advancedSettings.customHeader.key.description": "admin/store.advancedSettings.customHeader.key.description",
+  "admin/store.advancedSettings.customHeader.value.title": "admin/store.advancedSettings.customHeader.value.title",
+  "admin/store.advancedSettings.customHeader.value.description": "admin/store.advancedSettings.customHeader.value.description"
 }


### PR DESCRIPTION
#### What problem is this solving?

Typo in context message keys that might affect the label translations 

![image](https://github.com/user-attachments/assets/bfbb5cbf-b054-4487-8505-6cc9c610e8dd)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZW8wcTFzZndlbWx1OXhyOWVmYTFxdTY3bWxsbHltaW82dDlqb3liYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jPAdK8Nfzzwt2/giphy.gif)
