### PR TITLE
add sponsoredCount-prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- `sponsoredProductsBehavior` prop which is deprecated
+
+### Added
+- `sponsoredCount` prop
+
 ## [2.137.3] - 2024-10-08
 
 ### Changed

--- a/react/SearchContext.jsx
+++ b/react/SearchContext.jsx
@@ -26,7 +26,6 @@ const SearchContext = ({
   installmentCriteria,
   excludedPaymentSystems,
   includedPaymentSystems,
-  sponsoredProductsBehavior = 'sync',
   query: {
     order: orderBy = orderByField || SORT_OPTIONS[0].value,
     page: pageQuery,
@@ -39,6 +38,7 @@ const SearchContext = ({
     searchState,
   },
   children,
+  sponsoredCount,
   __unstableProductOriginVtex,
 }) => {
   const {
@@ -120,8 +120,8 @@ const SearchContext = ({
       operator={operator}
       fuzzy={fuzzy}
       searchState={state}
+      sponsoredCount={sponsoredCount}
       __unstableProductOriginVtex={__unstableProductOriginVtex}
-      sponsoredProductsBehavior={sponsoredProductsBehavior}
     >
       {(searchQuery, extraParams) => {
         return React.cloneElement(children, {
@@ -200,8 +200,8 @@ SearchContext.propTypes = {
   installmentCriteria: PropTypes.string,
   excludedPaymentSystems: PropTypes.string,
   includedPaymentSystems: PropTypes.string,
+  sponsoredCount: PropTypes.number,
   __unstableProductOriginVtex: PropTypes.bool,
-  sponsoredProductsBehavior: PropTypes.string,
 }
 
 SearchContext.schema = {
@@ -231,11 +231,6 @@ SearchContext.schema = {
       title: 'admin/editor.product-search.hideUnavailableItems',
       type: 'boolean',
       default: false,
-    },
-    sponsoredProductsBehavior: {
-      title: 'Sponsored products behavior',
-      type: 'string',
-      default: 'sync',
     },
   },
 }


### PR DESCRIPTION
#### What problem is this solving?

Currently, the maximum number of sponsoredProducts is hardcoded. This PR allows the developer to change it via store-theme. For example:

```
"store.search": {
    "blocks": ["search-result-layout"],
    "props": {
      "context": {
        "sponsoredCount": 4
      }
    }
  },
```

It also removes the `sponsoredProductsBehavior` which is a deprecated prop.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--savegnagoio.myvtex.com/shampoo?_q=shampoo&map=ft)


#### Related to / Depends on

https://github.com/vtex-apps/search-result/pull/691

