### PR TITLE
Added page, maxItemsPerPage and products to search metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- page, maxItemsPerPage and products to search metadata
+
 ## [2.139.0] - 2025-01-06
 
 ### Added

--- a/react/SearchWrapper.tsx
+++ b/react/SearchWrapper.tsx
@@ -287,6 +287,7 @@ interface SearchWrapperProps {
   orderBy?: string
   to?: number
   page?: number
+  maxItemsPerPage?: number
   CustomContext?: ComponentType
   facetsLoading?: boolean
 }
@@ -307,6 +308,7 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
     CustomContext,
     page: pageFromQuery = 0,
     to,
+    maxItemsPerPage,
     children,
   } = props
   const {
@@ -380,7 +382,9 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
       department: searchQuery?.data
         ? getDepartmentMetadata(searchQuery.data)
         : null,
-      search: searchQuery?.data ? getSearchMetadata(searchQuery.data) : null,
+      search: searchQuery?.data
+        ? getSearchMetadata(searchQuery.data, pageFromQuery, maxItemsPerPage)
+        : null,
     }
 
     return [
@@ -390,7 +394,18 @@ const SearchWrapper: FC<SearchWrapperProps> = props => {
         products,
       },
     ]
-  }, [searchQuery, facetsLoading, params, account, title, orderBy, map, page])
+  }, [
+    searchQuery,
+    facetsLoading,
+    params,
+    account,
+    title,
+    orderBy,
+    map,
+    page,
+    pageFromQuery,
+    maxItemsPerPage,
+  ])
 
   const [hasLoaded, setHasLoaded] = useState(true)
 

--- a/react/modules/searchMetadata.ts
+++ b/react/modules/searchMetadata.ts
@@ -103,7 +103,11 @@ export const getCategoryMetadata = (searchQuery?: SearchQueryData) => {
   }
 }
 
-export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
+export const getSearchMetadata = (
+  searchQuery?: SearchQueryData,
+  page?: number,
+  maxItemsPerPage?: number
+) => {
   if (
     !searchQuery ||
     !searchQuery.productSearch ||
@@ -128,6 +132,12 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
 
   const department = getDepartment(searchQuery)
 
+  const products = searchQuery?.products?.map(product => {
+    return {
+      productId: product.productId,
+    }
+  })
+
   return {
     term: decodedTerm || undefined,
     category: department ? { id: department.id, name: department.name } : null,
@@ -135,5 +145,8 @@ export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
     operator: searchQuery.productSearch.operator,
     searchState: searchQuery.productSearch.searchState,
     correction: searchQuery.productSearch.correction,
+    products,
+    page,
+    maxItemsPerPage,
   }
 }

--- a/react/modules/searchTypes.ts
+++ b/react/modules/searchTypes.ts
@@ -22,6 +22,7 @@ export interface SearchQueryData {
       misspelled: boolean
     }
   }
+  products?: Product[]
   facets?: Facets
 }
 
@@ -42,6 +43,10 @@ interface SpecificationFilter {
 export interface Breadcrumb {
   name: string
   href: string
+}
+
+export interface Product {
+  productId: string
 }
 
 export interface CategoriesTrees {


### PR DESCRIPTION
#### What problem is this solving?

This pull request adds more information in the search metadata object: current page, products per page and a list of products (with only the `productId` field available for now).

This new information will be used by the Intelligent Search analytics app: https://github.com/vtex/sae-analytics/pull/31.

#### How to test it?

- Go to a search result page.
- Using DevTools, find the request to `https://sp.vtex.com/event-api`.
- Check the request payload: the `page`, `count` and `products` fields are created using this new information. 

[Workspace](https://felipegarcia--biggy.myvtex.com/)

#### Related to / Depends on

Related to: https://github.com/vtex/sae-analytics/pull/31
