### PR TITLE
[SFSOC-95] - Add flag to enable default browser navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Setting to bypass render-runtime navigation (intended to be used in Fast Store accounts only)
+
 ## [2.140.0] - 2025-03-13
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -259,6 +259,12 @@
                 "value"
               ]
             }
+          },
+          "useDefaultBrowserNavigation": {
+            "title": "admin/store.advancedSettings.useDefaultBrowserNavigation.title",
+            "description": "admin/store.advancedSettings.useDefaultBrowserNavigation.description",
+            "type": "boolean",
+            "default": false
           }
         }
       }


### PR DESCRIPTION
#### What problem is this solving?

This PR adds a new flag to control bypass render runtime navigation logic, and using native browser navigation

Is related to [PR #478 in admin-pages](https://github.com/vtex-apps/admin-pages/pull/478)

#### How to test it?

[Workspace](https://paladinoteste--instoresetupqa.myvtex.com/)

* Load the workspace home
* Navigate to any PDP
  * You will notice a navigation progress bar at the top of the screen, indicating that it is using Render Runtime navigation solution
* Enable the new flag "Habilitar navegação nativa do navegador" can be enabled/disabled [here](https://paladinoteste--instoresetupqa.myvtex.com/admin/cms/store)
  * Wait a few minutes to avoid cached results, refresh the page, and click in the store logo, in the top left, for instance.
* Navigation progress bar should not be rendered anymore, indicating that we navigated through default browser navigation.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![asd](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExOTNlaHZvem14M25xanBvcXI2MHRkbW9nYmE0bTJjeW1vaWdvdW5qdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT5LMWOExnRmXt2vFS/giphy.gif)

