### PR TITLE
add vtex.shipping-option-components as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `vtex.shipping-option-components@1.x` as a dependency
+
 ### Changed
 
 - Update GitHub actions/cache to v4

--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,8 @@
     "vtex.product-review-interfaces": "1.x",
     "vtex.rich-text": "0.x",
     "vtex.native-types": "0.x",
-    "vtex.telemarketing": "2.x"
+    "vtex.telemarketing": "2.x",
+    "vtex.shipping-option-components": "1.x"
   },
   "settingsSchema": {
     "title": "admin/store.title",
@@ -89,10 +90,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "rel",
-            "href"
-          ]
+          "required": ["rel", "href"]
         },
         "description": "admin/store.faviconLinks.description"
       },
@@ -254,10 +252,7 @@
                   "description": "admin/store.advancedSettings.customHeader.value.description"
                 }
               },
-              "required": [
-                "key",
-                "value"
-              ]
+              "required": ["key", "value"]
             }
           },
           "useDefaultBrowserNavigation": {
@@ -275,18 +270,14 @@
           {
             "properties": {
               "requiresAuthorization": {
-                "enum": [
-                  false
-                ]
+                "enum": [false]
               }
             }
           },
           {
             "properties": {
               "requiresAuthorization": {
-                "enum": [
-                  true
-                ]
+                "enum": [true]
               },
               "b2bEnabled": {
                 "title": "admin/store.b2benabled.title",
@@ -307,12 +298,7 @@
     "b2bEnabled": {
       "ui:disabled": "true"
     },
-    "ui:order": [
-      "storeName",
-      "requiresAuthorization",
-      "b2bEnabled",
-      "*"
-    ]
+    "ui:order": ["storeName", "requiresAuthorization", "b2bEnabled", "*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
#### What problem is this solving?

Add the `vtex.shipping-option-components@1.x` as a dependency in `manifest.json`.
This PR precede the [PR that adds a `ShippingOptionProvider` as a wrapper](https://github.com/vtex-apps/store/pull/602)

#### How to test it?

[Workspace](https://hiago--storecomponents.myvtex.com/)

