### PR TITLE
Feat/change shipping options comopnents to delivery promise components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Add `vtex.delivery-promise-components` and keep `vtex.shipping-option-components@1.x` for backward compatibility.
+- `StoreWrapper` wraps the store with both `ShippingOptionProvider` (`vtex.shipping-option-components/ShippingOptionContext`) and `DeliveryPromiseProvider` (`vtex.delivery-promise-components/DeliveryPromiseContext`) so themes and apps can migrate gradually.
+
 ## [2.146.0] - 2025-12-18 [YANKED]
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.146.1-beta.0",
+  "version": "2.146.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store",
-  "version": "2.146.0",
+  "version": "2.146.1-beta.0",
   "title": "VTEX Store",
   "description": "The VTEX basic store.",
   "builders": {
@@ -35,6 +35,7 @@
     "vtex.rich-text": "0.x",
     "vtex.native-types": "0.x",
     "vtex.telemarketing": "2.x",
+    "vtex.delivery-promise-components": "1.x",
     "vtex.shipping-option-components": "1.x"
   },
   "settingsSchema": {

--- a/react/StoreWrapper.js
+++ b/react/StoreWrapper.js
@@ -14,6 +14,7 @@ import { PWAProvider } from 'vtex.store-resources/PWAContext'
 import { OrderQueueProvider } from 'vtex.order-manager/OrderQueue'
 import { OrderItemsProvider } from 'vtex.order-items/OrderItems'
 import { OrderFormProvider as OrderFormProviderCheckout } from 'vtex.order-manager/OrderForm'
+import { DeliveryPromiseProvider } from 'vtex.delivery-promise-components/DeliveryPromiseContext'
 import { ShippingOptionProvider } from 'vtex.shipping-option-components/ShippingOptionContext'
 
 import UserDataPixel from './components/UserDataPixel'
@@ -129,11 +130,13 @@ const StoreWrapper = ({ children, CustomContext }) => {
       <OrderFormProviderCheckout>
         <OrderItemsProvider>
           <ShippingOptionProvider>
-            <VTEXAdsProvider>
-              <WrapperContainer className="vtex-store__template bg-base">
-                <CustomContextElement>{children}</CustomContextElement>
-              </WrapperContainer>
-            </VTEXAdsProvider>
+            <DeliveryPromiseProvider>
+              <VTEXAdsProvider>
+                <WrapperContainer className="vtex-store__template bg-base">
+                  <CustomContextElement>{children}</CustomContextElement>
+                </WrapperContainer>
+              </VTEXAdsProvider>
+            </DeliveryPromiseProvider>
           </ShippingOptionProvider>
         </OrderItemsProvider>
       </OrderFormProviderCheckout>


### PR DESCRIPTION
#### What problem is this solving?

- Add`vtex.delivery-promise-components` DeliveryPromiseProvider context.
- We still keep the ShippingOptionProvider for compatibility reasons

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://dpcase1--vendemo.myvtex.com/polo?_q=polo&map=ft)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
