### PR TITLE
chore: STR-969 catalog platform-flow-id (Shopper#1, Shopper#2, CommDev#2)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -11,7 +11,7 @@ metadata:
     vtex.com/o11y-os-index: ""
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex-apps/store
-    vtex.com/platform-flow-id: ""
+    vtex.com/platform-flow-id: Shopper#1,Shopper#2,CommDev#2
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: 6BYLNHZR
 spec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update DK Catalog platform-flow-id
+
 ## [2.147.0] - 2026-04-08
 
 ### Changed


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Updates Backstage catalog metadata by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml` to match the **Platform Flows (Dark Kitchen)** classification for this component (initiative STR-969).

## Change

| Annotation | Value |
|------------|-------|
| `vtex.com/platform-flow-id` | `Shopper#1,Shopper#2,CommDev#2` |

**Convention:** multiple DK IDs are **comma-separated with no spaces**.

## Classification context (source artifact)

The following summary is taken from the internal classification table (Portuguese) used for STR-969:

> **App:** framework obrigatório das lojas IO (blocos, contratos). **Decisão:** README: todas as lojas usam; agrega PDP/PLP (**Shopper#1**), carrinho (**Shopper#2**), configuração de tema (**CommDev#2**).

## Changelog

- `CHANGELOG.md` — **[Unreleased]** → **Changed**: Update DK Catalog platform-flow-id


---

Reviewers: @vmourac-vtex @iago1501
